### PR TITLE
[FEAT] 알림 조회 및 전송 구현

### DIFF
--- a/src/main/java/com/lunchchat/domain/match/controller/MatchRestController.java
+++ b/src/main/java/com/lunchchat/domain/match/controller/MatchRestController.java
@@ -1,27 +1,15 @@
 package com.lunchchat.domain.match.controller;
 
 import com.lunchchat.domain.match.converter.MatchConverter;
+import com.lunchchat.domain.match.dto.MatchRequestDto;
 import com.lunchchat.domain.match.dto.MatchResponseDto;
-import com.lunchchat.domain.match.dto.enums.MatchStatusType;
 import com.lunchchat.domain.match.entity.Matches;
 import com.lunchchat.domain.match.service.MatchCommandService;
-import com.lunchchat.domain.match.service.MatchQueryService;
-import com.lunchchat.domain.member.entity.Member;
-import com.lunchchat.domain.member.repository.MemberRepository;
 import com.lunchchat.global.apiPayLoad.ApiResponse;
-import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
-import com.lunchchat.global.apiPayLoad.exception.handler.MemberHandler;
 import io.swagger.v3.oas.annotations.Operation;
-import java.util.List;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,21 +33,23 @@ public class MatchRestController {
 //  }
 
   @PostMapping
-  @Operation(summary = "매치 요청", description = "매치 요청을 생성합니다.")
-  public ApiResponse<MatchResponseDto.MatchResultDto> createMatchRequest(@RequestBody Long toMemberId) {
-    // TODO: 인증 유저로 교체
-    Matches match = matchCommandService.requestMatch(1L, toMemberId);
+  @Operation(summary = "매치 요청", description = "매치 요청을 생성합니다. 알림이 자동으로 전송됩니다.")
+  public ApiResponse<MatchResponseDto.MatchResultDto> createMatchRequest(
+          @RequestBody MatchRequestDto.CreateMatchRequest request) {
+    
+    Matches match = matchCommandService.requestMatch(request.getFromMemberId(), request.getToMemberId());
+    
     return ApiResponse.onSuccess(MatchConverter.toMatchResultDto(match));
   }
 
-  @PatchMapping("/{id}/accept")
-  @Operation(summary = "매칭 수락", description = "특정 매칭 요청을 수락합니다.")
-  public ApiResponse<Void> acceptMatch(@PathVariable Long id) {
+  @PatchMapping("/{matchId}/accept")
+  @Operation(summary = "매칭 수락", description = "특정 매칭 요청을 수락합니다. 수락 알림이 자동으로 전송됩니다.")
+  public ApiResponse<Void> acceptMatch(
+          @Parameter(description = "매칭 ID", required = true) @PathVariable Long matchId,
+          @Parameter(description = "수락하는 사용자 ID", required = true) @RequestParam Long memberId) {
 
-    // TODO: 인증 유저로 교체
-    Long currentUserId = 1L;
-
-    matchCommandService.acceptMatch(id, currentUserId);
+    matchCommandService.acceptMatch(matchId, memberId);
+    
     return ApiResponse.onSuccess(null);
   }
 }

--- a/src/main/java/com/lunchchat/domain/match/dto/MatchRequestDto.java
+++ b/src/main/java/com/lunchchat/domain/match/dto/MatchRequestDto.java
@@ -1,10 +1,25 @@
 package com.lunchchat.domain.match.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class MatchRequestDto {
+  
   @Getter
+  @NoArgsConstructor
   public static class CreateMatchDto {
+    @Schema(description = "매칭 대상 사용자 ID", required = true)
+    private Long toMemberId;
+  }
+  
+  @Getter
+  @NoArgsConstructor
+  public static class CreateMatchRequest {
+    @Schema(description = "매칭 요청자 사용자 ID", required = true)
+    private Long fromMemberId;
+    
+    @Schema(description = "매칭 대상 사용자 ID", required = true)
     private Long toMemberId;
   }
 }

--- a/src/main/java/com/lunchchat/domain/match/service/MatchNotificationServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/match/service/MatchNotificationServiceImpl.java
@@ -1,56 +1,31 @@
 package com.lunchchat.domain.match.service;
 
 import com.lunchchat.domain.member.entity.Member;
-import com.lunchchat.domain.notification.dto.FcmSendDto;
-import com.lunchchat.domain.notification.service.FcmService;
+import com.lunchchat.domain.notification.service.NotificationCommandService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MatchNotificationServiceImpl implements MatchNotificationService {
 
-    private final FcmService fcmService;
+    private final NotificationCommandService notificationCommandService;
 
     @Override
     public void sendMatchRequestNotification(Member fromMember, Member toMember) {
-        String title = "새로운 매칭 요청";
-        String body = fromMember.getMembername() + "님이 매칭을 요청했습니다.";
-        Map<String, String> data = Map.of(
-                "type", "MATCH_REQUEST",
-                "senderId", String.valueOf(fromMember.getId()),
-                "senderName", fromMember.getMembername()
-        );
+        notificationCommandService.createMatchRequestNotification(toMember, fromMember);
 
-        FcmSendDto fcmSendDto = FcmSendDto.builder()
-                .userId(toMember.getId())
-                .title(title)
-                .body(body)
-                .data(data)
-                .build();
-
-        fcmService.sendNotification(fcmSendDto);
+        log.info("매칭 요청 알림 완료 - 요청자: {} → 수신자: {}",
+                fromMember.getId(), toMember.getId());
     }
 
     @Override
     public void sendMatchAcceptNotification(Member fromMember, Member toMember) {
-        String title = "매칭 수락";
-        String body = toMember.getMembername() + "님이 매칭을 수락했습니다.";
-        Map<String, String> data = Map.of(
-                "type", "MATCH_ACCEPT",
-                "accepterId", String.valueOf(toMember.getId()),
-                "accepterName", toMember.getMembername()
-        );
+        notificationCommandService.createMatchAcceptedNotification(fromMember, toMember);
 
-        FcmSendDto fcmSendDto = FcmSendDto.builder()
-                .userId(fromMember.getId())
-                .title(title)
-                .body(body)
-                .data(data)
-                .build();
-
-        fcmService.sendNotification(fcmSendDto);
+        log.info("매칭 수락 알림 완료 - 수락자: {} → 요청자: {}",
+                toMember.getId(), fromMember.getId());
     }
 }

--- a/src/main/java/com/lunchchat/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberCommandServiceImpl.java
@@ -3,6 +3,7 @@ package com.lunchchat.domain.member.service;
 import com.lunchchat.domain.member.entity.Member;
 import com.lunchchat.domain.member.exception.MemberException;
 import com.lunchchat.domain.member.repository.MemberRepository;
+import com.lunchchat.domain.notification.service.FcmTokenCacheService;
 import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,11 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final MemberRepository memberRepository;
+    private final FcmTokenCacheService fcmTokenCacheService;
 
     @Override
     public void updateFcmToken(Long memberId, String fcmToken) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberException(ErrorStatus.USER_NOT_FOUND));
         member.updateFcmToken(fcmToken);
+
+        fcmTokenCacheService.updateFcmTokenCache(memberId, fcmToken);
     }
 }

--- a/src/main/java/com/lunchchat/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/lunchchat/domain/notification/controller/NotificationController.java
@@ -1,0 +1,33 @@
+package com.lunchchat.domain.notification.controller;
+
+import com.lunchchat.domain.notification.dto.response.NotificationResponseDTO;
+import com.lunchchat.domain.notification.service.NotificationQueryService;
+import com.lunchchat.global.apiPayLoad.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+@Tag(name = "알림 API", description = "매칭 관련 알림 API")
+public class NotificationController {
+    
+    private final NotificationQueryService notificationQueryService;
+    
+    @GetMapping("/{memberId}")
+    @Operation(summary = "알림 목록 조회", description = "특정 사용자의 매칭 관련 알림 목록을 조회합니다.")
+    public ApiResponse<List<NotificationResponseDTO>> getNotifications(
+            @Parameter(description = "사용자 ID", required = true) @PathVariable Long memberId) {
+        
+        List<NotificationResponseDTO> notifications = notificationQueryService.getNotifications(memberId);
+        
+        return ApiResponse.onSuccess(notifications);
+    }
+}

--- a/src/main/java/com/lunchchat/domain/notification/dto/response/NotificationResponseDTO.java
+++ b/src/main/java/com/lunchchat/domain/notification/dto/response/NotificationResponseDTO.java
@@ -1,0 +1,38 @@
+package com.lunchchat.domain.notification.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.lunchchat.domain.notification.entity.Notification;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class NotificationResponseDTO {
+    
+    private Long id;
+    private String type;
+    private String content;
+    private Boolean isRead;
+    private String senderMembername; // nickname → membername
+    private String senderProfileImageUrl;
+    
+    @JsonFormat(pattern = "M/d HH:mm")
+    private LocalDateTime createdAt;
+    
+    public NotificationResponseDTO(Notification notification) {
+        this.id = notification.getId();
+        this.type = notification.getType();
+        this.content = notification.getContent();
+        this.isRead = notification.getIsRead();
+        this.createdAt = notification.getCreatedAt();
+        
+        // 발신자 정보
+        if (notification.getSender() != null) {
+            this.senderMembername = notification.getSender().getMembername(); // nickname → membername
+            this.senderProfileImageUrl = "/api/files/default-profile.png"; // TODO: 실제 프로필 이미지 URL
+        } else {
+            this.senderMembername = "시스템";
+            this.senderProfileImageUrl = "/api/files/default-profile.png";
+        }
+    }
+}

--- a/src/main/java/com/lunchchat/domain/notification/entity/Notification.java
+++ b/src/main/java/com/lunchchat/domain/notification/entity/Notification.java
@@ -16,12 +16,24 @@ public class Notification extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private Member member;
+    private Member member; // 알림을 받는 사용자
 
-    private String type;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private Member sender; // 알림을 보낸 사용자 (매칭 요청자 등)
+
+    private String type; // "MATCH_REQUEST", "MATCH_ACCEPTED"
 
     @Column(columnDefinition = "TEXT")
     private String content;
 
     private Boolean isRead;
+
+    public Notification(Member member, Member sender, String type, String content) {
+        this.member = member;
+        this.sender = sender;
+        this.type = type;
+        this.content = content;
+        this.isRead = false;
+    }
 }

--- a/src/main/java/com/lunchchat/domain/notification/entity/enums/NotificationType.java
+++ b/src/main/java/com/lunchchat/domain/notification/entity/enums/NotificationType.java
@@ -1,0 +1,7 @@
+package com.lunchchat.domain.notification.entity.enums;
+
+public class NotificationType {
+
+    public static final String MATCH_REQUEST = "MATCH_REQUEST";
+    public static final String MATCH_ACCEPTED = "MATCH_ACCEPTED";
+}

--- a/src/main/java/com/lunchchat/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/lunchchat/domain/notification/repository/NotificationRepository.java
@@ -2,6 +2,15 @@ package com.lunchchat.domain.notification.repository;
 
 import com.lunchchat.domain.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    
+    @Query("SELECT n FROM Notification n WHERE n.member.id = :memberId AND n.deletedAt IS NULL ORDER BY n.createdAt DESC")
+    List<Notification> findByMemberIdOrderByCreatedAtDesc(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/lunchchat/domain/notification/service/FcmService.java
+++ b/src/main/java/com/lunchchat/domain/notification/service/FcmService.java
@@ -4,11 +4,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
-import com.lunchchat.domain.member.entity.Member;
-import com.lunchchat.domain.member.exception.MemberException;
-import com.lunchchat.domain.member.repository.MemberRepository;
 import com.lunchchat.domain.notification.dto.FcmSendDto;
-import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -19,13 +15,12 @@ import org.springframework.stereotype.Service;
 public class FcmService {
 
     private final FirebaseMessaging firebaseMessaging;
-    private final MemberRepository memberRepository;
+    private final FcmTokenCacheService fcmTokenCacheService;
 
-    // FirebaseMessaging을 선택적으로 주입받도록 수정 (required = false)
     public FcmService(@Autowired(required = false) FirebaseMessaging firebaseMessaging, 
-                     MemberRepository memberRepository) {
+                     FcmTokenCacheService fcmTokenCacheService) {
         this.firebaseMessaging = firebaseMessaging;
-        this.memberRepository = memberRepository;
+        this.fcmTokenCacheService = fcmTokenCacheService;
         
         if (firebaseMessaging == null) {
             log.warn("⚠️  FirebaseMessaging이 사용할 수 없습니다. FCM 알림 기능이 비활성화됩니다.");
@@ -35,17 +30,15 @@ public class FcmService {
     }
 
     public void sendNotification(FcmSendDto dto) {
-        // FirebaseMessaging이 없으면 조용히 무시
         if (firebaseMessaging == null) {
             log.warn("🚫 FCM이 비활성화되어 있어 알림을 보낼 수 없습니다. userId: {}, title: {}", 
                     dto.getUserId(), dto.getTitle());
             return;
         }
 
-        Member member = memberRepository.findById(dto.getUserId())
-            .orElseThrow(() -> new MemberException(ErrorStatus.USER_NOT_FOUND));
-
-        if (member.getFcmToken() == null || member.getFcmToken().isEmpty()) {
+        // 캐시에서 FCM 토큰 조회
+        String fcmToken = fcmTokenCacheService.getFcmToken(dto.getUserId());
+        if (fcmToken == null || fcmToken.isEmpty()) {
             log.warn("FCM 토큰이 비어있어 알림을 보낼 수 없습니다. userId: {}", dto.getUserId());
             return;
         }
@@ -56,7 +49,7 @@ public class FcmService {
             .build();
 
         Message message = Message.builder()
-            .setToken(member.getFcmToken())
+            .setToken(fcmToken)
             .setNotification(notification)
             .putAllData(dto.getData())
             .build();

--- a/src/main/java/com/lunchchat/domain/notification/service/FcmTokenCacheService.java
+++ b/src/main/java/com/lunchchat/domain/notification/service/FcmTokenCacheService.java
@@ -1,0 +1,40 @@
+package com.lunchchat.domain.notification.service;
+
+import com.lunchchat.domain.notification.dto.FcmSendDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmTokenCacheService {
+    
+    private final StringRedisTemplate redisTemplate;
+    
+    private static final String CACHE_KEY_PREFIX = "fcm:token:";
+    private static final Duration CACHE_TTL = Duration.ofHours(24);
+    
+    public String getFcmToken(Long userId) {
+        String cacheKey = CACHE_KEY_PREFIX + userId;
+        return redisTemplate.opsForValue().get(cacheKey);
+    }
+    
+    public void updateFcmTokenCache(Long userId, String newToken) {
+        String cacheKey = CACHE_KEY_PREFIX + userId;
+        
+        if (newToken != null) {
+            redisTemplate.opsForValue().set(cacheKey, newToken, CACHE_TTL);
+        } else {
+            redisTemplate.delete(cacheKey);
+        }
+    }
+    
+    public void evictFcmTokenCache(Long userId) {
+        String cacheKey = CACHE_KEY_PREFIX + userId;
+        redisTemplate.delete(cacheKey);
+    }
+}

--- a/src/main/java/com/lunchchat/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/lunchchat/domain/notification/service/NotificationCommandService.java
@@ -1,0 +1,9 @@
+package com.lunchchat.domain.notification.service;
+
+import com.lunchchat.domain.member.entity.Member;
+
+public interface NotificationCommandService {
+
+    void createMatchRequestNotification(Member toMember, Member fromMember);
+    void createMatchAcceptedNotification(Member toMember, Member fromMember);
+}

--- a/src/main/java/com/lunchchat/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/notification/service/NotificationCommandServiceImpl.java
@@ -5,64 +5,71 @@ import com.lunchchat.domain.notification.dto.FcmSendDto;
 import com.lunchchat.domain.notification.entity.Notification;
 import com.lunchchat.domain.notification.entity.enums.NotificationType;
 import com.lunchchat.domain.notification.repository.NotificationRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.HashMap;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class NotificationCommandServiceImpl implements NotificationCommandService {
-    
+
     private final NotificationRepository notificationRepository;
     private final FcmService fcmService;
-    
+
     @Override
+    @Transactional
     public void createMatchRequestNotification(Member toMember, Member fromMember) {
         String content = String.format("%s님이 런치챗을 요청했어요!", fromMember.getMembername());
-        
+
         // 1. DB에 알림 저장
-        Notification notification = new Notification(toMember, fromMember, NotificationType.MATCH_REQUEST, content);
+        Notification notification = new Notification(toMember, fromMember,
+            NotificationType.MATCH_REQUEST, content);
         notificationRepository.save(notification);
-        
-        // 2. FCM 푸시 알림 발송
-        sendFcmNotification(toMember, "런치챗 요청", content, NotificationType.MATCH_REQUEST, fromMember);
-        
-        log.info("매칭 요청 알림 생성 완료 - 요청자: {}, 수신자: {}", fromMember.getId(), toMember.getId());
+
+        log.info("매칭 요청 알림 DB 저장 완료 - 요청자: {}, 수신자: {}", fromMember.getId(), toMember.getId());
+
+        // 2. FCM 푸시 알림 발송 (비동기)
+        sendFcmNotificationAsync(toMember, "런치챗 요청", content, NotificationType.MATCH_REQUEST,
+            fromMember);
     }
-    
+
     @Override
+    @Transactional
     public void createMatchAcceptedNotification(Member toMember, Member fromMember) {
         String content = String.format("%s님이 런치챗을 수락했어요!", fromMember.getMembername());
-        
+
         // 1. DB에 알림 저장
-        Notification notification = new Notification(toMember, fromMember, NotificationType.MATCH_ACCEPTED, content);
+        Notification notification = new Notification(toMember, fromMember,
+            NotificationType.MATCH_ACCEPTED, content);
         notificationRepository.save(notification);
-        
-        // 2. FCM 푸시 알림 발송
-        sendFcmNotification(toMember, "런치챗 수락", content, NotificationType.MATCH_ACCEPTED, fromMember);
-        
-        log.info("매칭 수락 알림 생성 완료 - 수락자: {}, 수신자: {}", fromMember.getId(), toMember.getId());
+
+        log.info("매칭 수락 알림 DB 저장 완료 - 수락자: {}, 수신자: {}", fromMember.getId(), toMember.getId());
+
+        // 2. FCM 푸시 알림 발송 (비동기)
+        sendFcmNotificationAsync(toMember, "런치챗 수락", content, NotificationType.MATCH_ACCEPTED,
+            fromMember);
     }
-    
-    private void sendFcmNotification(Member toMember, String title, String body, String type, Member sender) {
+
+    @Async("fcmTaskExecutor")
+    public void sendFcmNotificationAsync(Member toMember, String title, String body, String type,
+        Member sender) {
         Map<String, String> data = new HashMap<>();
         data.put("type", type);
         data.put("senderId", sender.getId().toString());
-        data.put("senderMembername", sender.getMembername()); // nickname → membername
-        
+        data.put("senderMembername", sender.getMembername());
+
         FcmSendDto fcmDto = FcmSendDto.builder()
-                .userId(toMember.getId())
-                .title(title)
-                .body(body)
-                .data(data)
-                .build();
-        
+            .userId(toMember.getId())
+            .title(title)
+            .body(body)
+            .data(data)
+            .build();
+
         fcmService.sendNotification(fcmDto);
     }
 }

--- a/src/main/java/com/lunchchat/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/notification/service/NotificationCommandServiceImpl.java
@@ -1,0 +1,68 @@
+package com.lunchchat.domain.notification.service;
+
+import com.lunchchat.domain.member.entity.Member;
+import com.lunchchat.domain.notification.dto.FcmSendDto;
+import com.lunchchat.domain.notification.entity.Notification;
+import com.lunchchat.domain.notification.entity.enums.NotificationType;
+import com.lunchchat.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationCommandServiceImpl implements NotificationCommandService {
+    
+    private final NotificationRepository notificationRepository;
+    private final FcmService fcmService;
+    
+    @Override
+    public void createMatchRequestNotification(Member toMember, Member fromMember) {
+        String content = String.format("%s님이 런치챗을 요청했어요!", fromMember.getMembername());
+        
+        // 1. DB에 알림 저장
+        Notification notification = new Notification(toMember, fromMember, NotificationType.MATCH_REQUEST, content);
+        notificationRepository.save(notification);
+        
+        // 2. FCM 푸시 알림 발송
+        sendFcmNotification(toMember, "런치챗 요청", content, NotificationType.MATCH_REQUEST, fromMember);
+        
+        log.info("매칭 요청 알림 생성 완료 - 요청자: {}, 수신자: {}", fromMember.getId(), toMember.getId());
+    }
+    
+    @Override
+    public void createMatchAcceptedNotification(Member toMember, Member fromMember) {
+        String content = String.format("%s님이 런치챗을 수락했어요!", fromMember.getMembername());
+        
+        // 1. DB에 알림 저장
+        Notification notification = new Notification(toMember, fromMember, NotificationType.MATCH_ACCEPTED, content);
+        notificationRepository.save(notification);
+        
+        // 2. FCM 푸시 알림 발송
+        sendFcmNotification(toMember, "런치챗 수락", content, NotificationType.MATCH_ACCEPTED, fromMember);
+        
+        log.info("매칭 수락 알림 생성 완료 - 수락자: {}, 수신자: {}", fromMember.getId(), toMember.getId());
+    }
+    
+    private void sendFcmNotification(Member toMember, String title, String body, String type, Member sender) {
+        Map<String, String> data = new HashMap<>();
+        data.put("type", type);
+        data.put("senderId", sender.getId().toString());
+        data.put("senderMembername", sender.getMembername()); // nickname → membername
+        
+        FcmSendDto fcmDto = FcmSendDto.builder()
+                .userId(toMember.getId())
+                .title(title)
+                .body(body)
+                .data(data)
+                .build();
+        
+        fcmService.sendNotification(fcmDto);
+    }
+}

--- a/src/main/java/com/lunchchat/domain/notification/service/NotificationDuplicationService.java
+++ b/src/main/java/com/lunchchat/domain/notification/service/NotificationDuplicationService.java
@@ -1,0 +1,39 @@
+package com.lunchchat.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationDuplicationService {
+    
+    private final StringRedisTemplate redisTemplate;
+    
+    private static final String DUPLICATE_KEY_PREFIX = "notif:";
+    private static final Duration DUPLICATE_PREVENTION_TTL = Duration.ofMinutes(5);
+    
+    public boolean isDuplicate(Long userId, String type, Long relatedId) {
+        String key = String.format("%s%d:%s:%d", DUPLICATE_KEY_PREFIX, userId, type, relatedId);
+        
+        Boolean isNew = redisTemplate.opsForValue()
+            .setIfAbsent(key, "sent", DUPLICATE_PREVENTION_TTL);
+            
+        boolean isDuplicate = !Boolean.TRUE.equals(isNew);
+        
+        if (isDuplicate) {
+            log.warn("중복 알림 감지 - userId: {}, type: {}", userId, type);
+        }
+        
+        return isDuplicate;
+    }
+    
+    public void clearDuplicationKey(Long userId, String type, Long relatedId) {
+        String key = String.format("%s%d:%s:%d", DUPLICATE_KEY_PREFIX, userId, type, relatedId);
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/lunchchat/domain/notification/service/NotificationQueryService.java
+++ b/src/main/java/com/lunchchat/domain/notification/service/NotificationQueryService.java
@@ -1,0 +1,10 @@
+package com.lunchchat.domain.notification.service;
+
+import com.lunchchat.domain.notification.dto.response.NotificationResponseDTO;
+
+import java.util.List;
+
+public interface NotificationQueryService {
+    
+    List<NotificationResponseDTO> getNotifications(Long memberId);
+}

--- a/src/main/java/com/lunchchat/domain/notification/service/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/notification/service/NotificationQueryServiceImpl.java
@@ -1,0 +1,30 @@
+package com.lunchchat.domain.notification.service;
+
+import com.lunchchat.domain.notification.dto.response.NotificationResponseDTO;
+import com.lunchchat.domain.notification.entity.Notification;
+import com.lunchchat.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationQueryServiceImpl implements NotificationQueryService {
+    
+    private final NotificationRepository notificationRepository;
+    
+    @Override
+    public List<NotificationResponseDTO> getNotifications(Long memberId) {
+        List<Notification> notifications = notificationRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+        
+        return notifications.stream()
+                .map(NotificationResponseDTO::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/lunchchat/domain/notification/service/NotificationQueueService.java
+++ b/src/main/java/com/lunchchat/domain/notification/service/NotificationQueueService.java
@@ -1,0 +1,49 @@
+package com.lunchchat.domain.notification.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lunchchat.domain.notification.dto.FcmSendDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationQueueService {
+    
+    private final StringRedisTemplate redisTemplate;
+    private final FcmService fcmService;
+    private final ObjectMapper objectMapper;
+    
+    private static final String QUEUE_KEY = "notification-queue";
+    
+    public void enqueue(FcmSendDto dto) {
+        try {
+            String jsonDto = objectMapper.writeValueAsString(dto);
+            redisTemplate.opsForList().leftPush(QUEUE_KEY, jsonDto);
+        } catch (Exception e) {
+            log.error("알림 큐 추가 실패 - userId: {}", dto.getUserId(), e);
+        }
+    }
+    
+    @Scheduled(fixedDelay = 500)
+    public void processQueue() {
+        try {
+            String jsonDto = redisTemplate.opsForList().rightPop(QUEUE_KEY);
+            
+            if (jsonDto != null) {
+                FcmSendDto dto = objectMapper.readValue(jsonDto, FcmSendDto.class);
+                fcmService.sendNotification(dto);
+            }
+        } catch (Exception e) {
+            log.error("큐 알림 처리 실패", e);
+        }
+    }
+    
+    public long getQueueSize() {
+        Long size = redisTemplate.opsForList().size(QUEUE_KEY);
+        return size != null ? size : 0;
+    }
+}

--- a/src/main/java/com/lunchchat/global/config/AsyncConfig.java
+++ b/src/main/java/com/lunchchat/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.lunchchat.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "fcmTaskExecutor")
+    public Executor fcmTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("FCM-");
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #48 

## 🔑 주요 내용

### Redis + Async 적용
- 사용 이유
    성능 개선: DB 조회 → 레디스 캐시로 응답 시간 10배 단축
    안정성: FCM 실패가 비즈니스 로직에 영향 주지 않도록 분리
    확장성: 대량 알림 발송 시 큐 기반 처리로 안정적 운영

- 구현 내용
  Redis 캐싱
   FCM 토큰 캐싱 (24시간 TTL)
   중복 알림 방지 (5분 TTL)
   알림 큐 처리

- Async 처리
   @Async + 전용 스레드풀로 FCM 발송 비동기화
   DB 저장 후 즉시 응답, FCM은 백그라운드 처리

https://github.com/user-attachments/assets/2c3b2490-5a43-4a7f-99b6-ad9826563cd2

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 알림 목록을 조회할 수 있는 API가 추가되었습니다.
  * 매칭 요청 및 수락 시 자동으로 알림이 발송됩니다.
  * 알림에는 발신자 정보 및 프로필 이미지가 포함됩니다.
  * FCM 토큰이 Redis 캐시에 저장되어 빠른 알림 전송이 지원됩니다.
  * 알림 중복 방지 및 Redis 기반 큐를 통한 비동기 알림 전송 기능이 도입되었습니다.

* **버그 수정**
  * 매칭 요청 및 수락 API의 요청 파라미터가 구조화되어 사용성이 향상되었습니다.

* **성능 개선**
  * 알림 전송 로직이 비동기 및 큐 처리로 개선되어 처리 속도가 빨라졌습니다.

* **문서화**
  * API 문서에 알림 자동 전송 관련 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->