### PR TITLE
[FEAT] 관심사 태그 관련 API 구현

### DIFF
--- a/src/main/java/com/lunchchat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/lunchchat/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.lunchchat.domain.member.controller;
 
+import com.lunchchat.domain.member.dto.MemberRequestDTO;
 import com.lunchchat.domain.member.dto.MemberResponseDTO;
 import com.lunchchat.domain.member.entity.Member;
 import com.lunchchat.domain.member.service.MemberCommandService;
@@ -7,9 +8,12 @@ import com.lunchchat.domain.member.service.MemberQueryService;
 import com.lunchchat.domain.notification.dto.FcmUpdateRequestDto;
 import com.lunchchat.global.apiPayLoad.ApiResponse;
 import com.lunchchat.global.apiPayLoad.code.status.SuccessStatus;
+import com.lunchchat.global.security.auth.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -82,5 +86,12 @@ public class MemberController {
         return ApiResponse.onSuccess(myPage);
     }
 
+    @PatchMapping("me/tags")
+    @Operation(summary = "사용자 관심사 태그 업데이트", description = "사용자의 관심사 태그를 업데이트합니다.")
+    public ApiResponse<SuccessStatus> updateUserInterest(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody @Valid MemberRequestDTO.UpdateInterestDTO request) {
+        String email = userDetails.getUsername();
+        memberCommandService.updateInterests(email, request.getInterestIds());
+        return ApiResponse.onSuccess(SuccessStatus.INTERESTS_UPDATE_SUCCESS);
+    }
 }
 

--- a/src/main/java/com/lunchchat/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/lunchchat/domain/member/dto/MemberRequestDTO.java
@@ -1,0 +1,16 @@
+package com.lunchchat.domain.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Getter;
+
+public class MemberRequestDTO {
+  @Getter
+  public static class UpdateInterestDTO {
+
+    @NotNull
+    @Size(max = 3, message = "최대 3개의 관심사를 선택할 수 있습니다.")
+    List<Long> interestIds;
+  }
+}

--- a/src/main/java/com/lunchchat/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberCommandService.java
@@ -1,6 +1,9 @@
 package com.lunchchat.domain.member.service;
 
+import java.util.List;
+
 public interface MemberCommandService {
 
     void updateFcmToken(Long memberId, String fcmToken);
+    void updateInterests(String email, List<Long> interestIds);
 }

--- a/src/main/java/com/lunchchat/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberCommandServiceImpl.java
@@ -3,7 +3,11 @@ package com.lunchchat.domain.member.service;
 import com.lunchchat.domain.member.entity.Member;
 import com.lunchchat.domain.member.exception.MemberException;
 import com.lunchchat.domain.member.repository.MemberRepository;
+import com.lunchchat.domain.user_interests.entity.Interest;
+import com.lunchchat.domain.user_interests.repository.InterestRepository;
 import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
+import java.util.HashSet;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,11 +18,31 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final MemberRepository memberRepository;
+    private final InterestRepository interestRepository;
 
     @Override
     public void updateFcmToken(Long memberId, String fcmToken) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberException(ErrorStatus.USER_NOT_FOUND));
         member.updateFcmToken(fcmToken);
+    }
+
+    @Override
+    @Transactional
+    public void updateInterests(String email, List<Long> interestIds) {
+        if (interestIds.size() > 3) {
+            throw new MemberException(ErrorStatus.INTERESTS_LIMIT_EXCEEDED);
+        }
+
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new MemberException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Interest> interests = interestRepository.findAllById(interestIds);
+
+        if (interests.size() != interestIds.size()) {
+            throw new MemberException(ErrorStatus.INTERESTS_NOT_FOUND);
+        }
+
+        member.setInterests(new HashSet<>(interests));
     }
 }

--- a/src/main/java/com/lunchchat/domain/user_interests/controller/UserInterestController.java
+++ b/src/main/java/com/lunchchat/domain/user_interests/controller/UserInterestController.java
@@ -1,0 +1,28 @@
+package com.lunchchat.domain.user_interests.controller;
+
+import com.lunchchat.domain.user_interests.converter.UserInterestConverter;
+import com.lunchchat.domain.user_interests.dto.UserInterestResponseDTO;
+import com.lunchchat.domain.user_interests.entity.Interest;
+import com.lunchchat.domain.user_interests.service.UserInterestQueryService;
+import com.lunchchat.global.apiPayLoad.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/tags")
+public class UserInterestController {
+
+  private final UserInterestQueryService userInterestQueryService;
+
+  @GetMapping
+  @Operation(summary = "관심사 태그 목록 조회", description = "사용 가능한 관심사 목록을 조회합니다.")
+  public ApiResponse<UserInterestResponseDTO.UserInterestListDTO> getInterests() {
+    List<Interest> interests = userInterestQueryService.getInterests();
+    return ApiResponse.onSuccess(UserInterestConverter.toUserInterestPreviewDTO(interests));
+  }
+}

--- a/src/main/java/com/lunchchat/domain/user_interests/converter/UserInterestConverter.java
+++ b/src/main/java/com/lunchchat/domain/user_interests/converter/UserInterestConverter.java
@@ -5,18 +5,15 @@ import com.lunchchat.domain.user_interests.entity.Interest;
 import java.util.List;
 
 public class UserInterestConverter {
-  public static UserInterestResponseDTO.UserInterestListDTO toUserInterestPreviewDTO(
-      List<Interest> interests) {
+
+  public static UserInterestResponseDTO.UserInterestListDTO toUserInterestPreviewDTO(List<Interest> interests) {
     List<UserInterestResponseDTO.UserInterestPreviewDTO> previewList = interests.stream()
-        .map(interest -> UserInterestResponseDTO.UserInterestPreviewDTO.builder()
-            .id(interest.getId())
-            .interestType(interest.getType())
-            .build())
+        .map(interest -> new UserInterestResponseDTO.UserInterestPreviewDTO(
+            interest.getId(),
+            interest.getType()))
         .toList();
 
-    return UserInterestResponseDTO.UserInterestListDTO.builder()
-        .interests(previewList)
-        .build();
+    return new UserInterestResponseDTO.UserInterestListDTO(previewList);
   }
 
 }

--- a/src/main/java/com/lunchchat/domain/user_interests/converter/UserInterestConverter.java
+++ b/src/main/java/com/lunchchat/domain/user_interests/converter/UserInterestConverter.java
@@ -1,0 +1,22 @@
+package com.lunchchat.domain.user_interests.converter;
+
+import com.lunchchat.domain.user_interests.dto.UserInterestResponseDTO;
+import com.lunchchat.domain.user_interests.entity.Interest;
+import java.util.List;
+
+public class UserInterestConverter {
+  public static UserInterestResponseDTO.UserInterestListDTO toUserInterestPreviewDTO(
+      List<Interest> interests) {
+    List<UserInterestResponseDTO.UserInterestPreviewDTO> previewList = interests.stream()
+        .map(interest -> UserInterestResponseDTO.UserInterestPreviewDTO.builder()
+            .id(interest.getId())
+            .interestType(interest.getType())
+            .build())
+        .toList();
+
+    return UserInterestResponseDTO.UserInterestListDTO.builder()
+        .interests(previewList)
+        .build();
+  }
+
+}

--- a/src/main/java/com/lunchchat/domain/user_interests/dto/UserInterestResponseDTO.java
+++ b/src/main/java/com/lunchchat/domain/user_interests/dto/UserInterestResponseDTO.java
@@ -1,0 +1,28 @@
+package com.lunchchat.domain.user_interests.dto;
+
+import com.lunchchat.domain.member.entity.enums.InterestType;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserInterestResponseDTO {
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class UserInterestListDTO {
+    private List<UserInterestPreviewDTO> interests;
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class UserInterestPreviewDTO {
+    private Long id;
+    private InterestType interestType;
+  }
+
+}

--- a/src/main/java/com/lunchchat/domain/user_interests/dto/UserInterestResponseDTO.java
+++ b/src/main/java/com/lunchchat/domain/user_interests/dto/UserInterestResponseDTO.java
@@ -2,27 +2,11 @@ package com.lunchchat.domain.user_interests.dto;
 
 import com.lunchchat.domain.member.entity.enums.InterestType;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public class UserInterestResponseDTO {
-  @Getter
-  @Builder
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class UserInterestListDTO {
-    private List<UserInterestPreviewDTO> interests;
-  }
 
-  @Getter
-  @Builder
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class UserInterestPreviewDTO {
-    private Long id;
-    private InterestType interestType;
-  }
+  public record UserInterestListDTO(List<UserInterestPreviewDTO> interests) {}
+
+  public record UserInterestPreviewDTO(Long id, InterestType interestType) {}
 
 }

--- a/src/main/java/com/lunchchat/domain/user_interests/service/UserInterestQueryService.java
+++ b/src/main/java/com/lunchchat/domain/user_interests/service/UserInterestQueryService.java
@@ -1,0 +1,8 @@
+package com.lunchchat.domain.user_interests.service;
+
+import com.lunchchat.domain.user_interests.entity.Interest;
+import java.util.List;
+
+public interface UserInterestQueryService {
+  List<Interest> getInterests();
+}

--- a/src/main/java/com/lunchchat/domain/user_interests/service/UserInterestQueryServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/user_interests/service/UserInterestQueryServiceImpl.java
@@ -1,0 +1,20 @@
+package com.lunchchat.domain.user_interests.service;
+
+import com.lunchchat.domain.user_interests.entity.Interest;
+import com.lunchchat.domain.user_interests.repository.InterestRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserInterestQueryServiceImpl implements UserInterestQueryService{
+
+  private final InterestRepository interestRepository;
+
+  @Override
+  public List<Interest> getInterests() {
+    return interestRepository.findAll();
+  }
+
+}

--- a/src/main/java/com/lunchchat/global/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/com/lunchchat/global/apiPayLoad/code/status/ErrorStatus.java
@@ -55,6 +55,10 @@ public enum ErrorStatus implements BaseErrorCode {
   INVALID_MATCH_ID(HttpStatus.BAD_REQUEST, "MATCH_400", "유효하지 않은 매칭 ID입니다."),
   MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH_404", "매칭을 찾을 수 없습니다."),
 
+  // Interest Error
+  INTERESTS_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "INTEREST_400", "관심사는 최대 3개까지만 선택할 수 있습니다."),
+  INTERESTS_NOT_FOUND(HttpStatus.NOT_FOUND, "INTEREST_404", "선택한 관심사를 찾을 수 없습니다."),
+
   // Chat Error
   CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404", "해당 채팅방이 존재하지 않습니다."),
   CANNOT_CHAT_WITH_SELF(HttpStatus.BAD_REQUEST, "CHAT400", "자기 자신과는 채팅할 수 없습니다."),

--- a/src/main/java/com/lunchchat/global/apiPayLoad/code/status/SuccessStatus.java
+++ b/src/main/java/com/lunchchat/global/apiPayLoad/code/status/SuccessStatus.java
@@ -16,6 +16,9 @@ public enum SuccessStatus implements BaseCode {
     // FCM 관련 응답
     FCM_TOKEN_UPDATE_SUCCESS(HttpStatus.OK, "FCM200", "FCM 토큰이 성공적으로 업데이트되었습니다."),
 
+    // 관심사 관련 응답
+    INTERESTS_UPDATE_SUCCESS(HttpStatus.OK, "INTERESTS200", "관심사가 성공적으로 업데이트되었습니다."),
+
     // 로그인 응답
     USER_LOGIN_OK(HttpStatus.OK, "USER200", "유저 로그인 성공"),
     USER_SIGNUP_OK(HttpStatus.OK, "USER201", "유저 회원가입 성공");


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치
#32 

## 🔑 주요 내용

- 주요 변경점 간단 요약
- 관심사 태그 조회, 수정 API를 구현했습니다.

#### 조회
<img width="1582" height="958" alt="image" src="https://github.com/user-attachments/assets/7d8704f6-3f2f-458e-aa87-ea4cfd869c1c" />

#### 수정
<img width="1582" height="958" alt="image" src="https://github.com/user-attachments/assets/d1be2290-0975-4cdc-8f8b-b62b0e535784" />
<img width="441" height="95" alt="image" src="https://github.com/user-attachments/assets/99c65919-3e8b-4f5e-972f-2ffc29833282" />

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 자신의 관심 태그(최대 3개까지)를 조회하고 수정할 수 있는 API가 추가되었습니다.
  * 관심 태그 목록을 조회할 수 있는 새로운 엔드포인트가 제공됩니다.

* **버그 수정**
  * 관심 태그 선택 시 최대 개수 초과 및 존재하지 않는 태그 선택에 대한 오류 메시지가 추가되었습니다.

* **문서화**
  * 관심 태그 관련 API에 대한 Swagger 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->