### PR TITLE
[FEAT] 마이페이지 조회 API에 로그인 유저 적용

### DIFF
--- a/src/main/java/com/lunchchat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/lunchchat/domain/member/controller/MemberController.java
@@ -79,9 +79,8 @@ public class MemberController {
 
     @GetMapping("/mypage")
     @Operation(summary = "마이페이지 조회", description = "마이페이지를 조회합니다.")
-    public ApiResponse<MemberResponseDTO.MyPageResponseDTO> getMyPageInfo(Member member) {
-        // TODO: 현재는 하드코딩된 memberId를 사용하고 있습니다. 추후 인증 시스템이 구현되면 수정 필요.
-        MemberResponseDTO.MyPageResponseDTO myPage = memberQueryService.getMyPage(1L);
+    public ApiResponse<MemberResponseDTO.MyPageResponseDTO> getMyPageInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        MemberResponseDTO.MyPageResponseDTO myPage = memberQueryService.getMyPage(userDetails.getUsername());
         return ApiResponse.onSuccess(myPage);
     }
 

--- a/src/main/java/com/lunchchat/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/lunchchat/domain/member/converter/MemberConverter.java
@@ -3,6 +3,7 @@ package com.lunchchat.domain.member.converter;
 import com.lunchchat.domain.match.dto.enums.MatchStatusType;
 import com.lunchchat.domain.member.dto.MemberResponseDTO;
 import com.lunchchat.domain.member.entity.Member;
+import com.lunchchat.domain.member.entity.enums.InterestType;
 import com.lunchchat.domain.time_table.converter.TimeTableConverter;
 import com.lunchchat.domain.user_interests.dto.UserInterestDTO;
 import com.lunchchat.domain.user_interests.entity.Interest;
@@ -45,7 +46,7 @@ public class MemberConverter {
     }
 
     public static MemberResponseDTO.MyPageResponseDTO toMyPageDto(Member member,
-        int completed, int requested, int received, List<String> keywords, List<String> tags) {
+        int completed, int requested, int received, List<String> keywords, List<InterestType> tags) {
 
         return MemberResponseDTO.MyPageResponseDTO.builder()
             .profileImageUrl(member.getProfileImageUrl())

--- a/src/main/java/com/lunchchat/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/lunchchat/domain/member/dto/MemberResponseDTO.java
@@ -67,7 +67,7 @@ public class MemberResponseDTO {
         private int requested;
         private int received;
         private List<String> keywords;
-        private List<String> tags;
+        private List<InterestType> tags;
 
     }
 }

--- a/src/main/java/com/lunchchat/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberQueryService.java
@@ -8,6 +8,6 @@ import java.util.List;
 public interface MemberQueryService {
     MemberResponseDTO.MemberDetailResponseDTO getMemberDetail(Long memberId, String viewerEmail);
     List<MemberResponseDTO.MemberRecommendationResponseDTO> getRecommendedMembers(Long currentMemberId);
-    MemberResponseDTO.MyPageResponseDTO getMyPage(Long memberId);
+    MemberResponseDTO.MyPageResponseDTO getMyPage(String email);
     List<MemberResponseDTO.MemberRecommendationResponseDTO> getFilteredRecommendations(String email, MemberFilterRequestDTO req);
 }

--- a/src/main/java/com/lunchchat/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberQueryServiceImpl.java
@@ -13,6 +13,7 @@ import com.lunchchat.domain.member.dto.MemberResponseDTO.MemberRecommendationRes
 import com.lunchchat.domain.member.dto.MemberResponseDTO.MyPageResponseDTO;
 import com.lunchchat.domain.member.dto.MemberScoreWrapper;
 import com.lunchchat.domain.member.entity.Member;
+import com.lunchchat.domain.member.entity.enums.InterestType;
 import com.lunchchat.domain.member.exception.MemberException;
 import com.lunchchat.domain.member.repository.MemberRepository;
 import com.lunchchat.domain.time_table.entity.TimeTable;
@@ -20,6 +21,7 @@ import com.lunchchat.domain.time_table.service.TimeTableQueryService;
 import com.lunchchat.domain.user_interests.entity.Interest;
 import com.lunchchat.domain.user_interests.repository.InterestRepository;
 import com.lunchchat.domain.user_keywords.repository.UserKeywordsRepository;
+import com.lunchchat.domain.user_statistics.entity.UserStatistics;
 import com.lunchchat.domain.user_statistics.repository.UserStatisticsRepository;
 import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
 import com.lunchchat.global.security.jwt.JwtTokenProvider;
@@ -200,33 +202,26 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         return true;
     }
 
-
-
     @Override
-    public MyPageResponseDTO getMyPage(Long memberId) {
-        return null;
-    }
+    @Transactional(readOnly = true)
+    public MemberResponseDTO.MyPageResponseDTO getMyPage(String email) {
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new MemberException(ErrorStatus.USER_NOT_FOUND));
 
-//
-//  @Override
-//  public MemberResponseDTO.MyPageResponseDTO getMyPage(Long memberId) {
-//    Member member = memberRepository.findById(memberId)
-//        .orElseThrow(() -> new MemberException(ErrorStatus.USER_NOT_FOUND));
-//
-//    UserStatistics userStatistics = userStatisticsRepository.findByMemberId(memberId)
-//        .orElseThrow(() -> new MemberException(ErrorStatus.USER_STATISTICS_NOT_FOUND));
-//
-//    List<String> keywords = userKeywordsRepository.findTitlesByMemberId(memberId);
-//    List<String> tags = userInterestsRepository.findInterestNamesByMemberId(memberId);
-//
-//    return MemberConverter.toMyPageDto(
-//        member,
-//        userStatistics.getMatchCompletedCount(),
-//        userStatistics.getMatchRequestedCount(),
-//        userStatistics.getMatchReceivedCount(),
-//        keywords,
-//        tags
-//    );
-//  }
+        UserStatistics userStatistics = userStatisticsRepository.findByMemberId(member.getId())
+            .orElseThrow(() -> new MemberException(ErrorStatus.USER_STATISTICS_NOT_FOUND));
+
+        List<String> keywords = userKeywordsRepository.findTitlesByMemberId(member.getId());
+        List<InterestType> tags = userInterestsRepository.findInterestTypesByMemberId(member.getId());
+
+        return MemberConverter.toMyPageDto(
+            member,
+            userStatistics.getMatchCompletedCount(),
+            userStatistics.getMatchRequestedCount(),
+            userStatistics.getMatchReceivedCount(),
+            keywords,
+            tags
+        );
+      }
 }
 

--- a/src/main/java/com/lunchchat/domain/user_interests/repository/InterestRepository.java
+++ b/src/main/java/com/lunchchat/domain/user_interests/repository/InterestRepository.java
@@ -2,12 +2,15 @@ package com.lunchchat.domain.user_interests.repository;
 
 import com.lunchchat.domain.member.entity.enums.InterestType;
 import com.lunchchat.domain.user_interests.entity.Interest;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InterestRepository extends JpaRepository<Interest, Long> {
-//  @Query("SELECT ui.interests.name FROM Interest ui WHERE ui.user.id = :memberId")
-//  List<String> findInterestNamesByMemberId(@Param("memberId") Long memberId);
+  @Query("SELECT i.type FROM Member m JOIN m.interests i WHERE m.id = :memberId")
+  List<InterestType> findInterestTypesByMemberId(@Param("memberId") Long memberId);
 
   // 관심사 정합성 확인
   Optional<Interest> findByType(InterestType type);


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치
#25 

## 🔑 주요 내용

" 주요 변경점 간단 요약
- 기존 마이페이지 정보 조회에 현재 로그인한 사용자 정보를 포함할 수 있도록 수정했습니다.
<img width="1582" height="958" alt="image" src="https://github.com/user-attachments/assets/e408039c-4502-41cb-9bcd-21164e091de5" />

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
