### PR TITLE
[FEAT] 키워드 등록 및 조회 API 구현

### DIFF
--- a/src/main/java/com/lunchchat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/lunchchat/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.lunchchat.domain.member.repository.MemberRepository;
 import com.lunchchat.domain.member.service.MemberCommandService;
 import com.lunchchat.domain.member.service.MemberQueryService;
 import com.lunchchat.domain.notification.dto.FcmUpdateRequestDto;
+import com.lunchchat.domain.user_keywords.dto.UserKeywordDTO;
 import com.lunchchat.global.apiPayLoad.ApiResponse;
 import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
 import com.lunchchat.global.apiPayLoad.code.status.SuccessStatus;
@@ -101,5 +102,14 @@ public class MemberController {
         String email = userDetails.getUsername();
         memberCommandService.updateKeywords(email, request);
         return ApiResponse.onSuccess(SuccessStatus.KEYWORDS_UPDATE_SUCCESS);
+    }
+
+    @GetMapping("/keywords")
+    @Operation(summary = "내 키워드 조회", description = "현재 로그인한 사용자의 키워드를 조회합니다.")
+    public ApiResponse<List<UserKeywordDTO>> getMyKeywords(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        String email = userDetails.getUsername();
+        List<UserKeywordDTO> keywords = memberQueryService.getUserKeywords(email);
+        return ApiResponse.onSuccess(keywords);
     }
 }

--- a/src/main/java/com/lunchchat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/lunchchat/domain/member/controller/MemberController.java
@@ -85,11 +85,21 @@ public class MemberController {
         return ApiResponse.onSuccess(myPage);
     }
 
-    @PatchMapping("me/tags")
+    @PatchMapping("/me/tags")
     @Operation(summary = "사용자 관심사 태그 업데이트", description = "사용자의 관심사 태그를 업데이트합니다.")
     public ApiResponse<SuccessStatus> updateUserInterest(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody @Valid MemberRequestDTO.UpdateInterestDTO request) {
         String email = userDetails.getUsername();
         memberCommandService.updateInterests(email, request.getInterestIds());
         return ApiResponse.onSuccess(SuccessStatus.INTERESTS_UPDATE_SUCCESS);
+    }
+
+    @PatchMapping("/keywords")
+    @Operation(summary = "사용자 키워드 등록", description = "사용자의 키워드를 등록 또는 업데이트합니다.")
+    public ApiResponse<SuccessStatus> updateUserKeywords(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid MemberRequestDTO.UpdateKeywordListDTO request) {
+        String email = userDetails.getUsername();
+        memberCommandService.updateKeywords(email, request);
+        return ApiResponse.onSuccess(SuccessStatus.KEYWORDS_UPDATE_SUCCESS);
     }
 }

--- a/src/main/java/com/lunchchat/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/lunchchat/domain/member/dto/MemberRequestDTO.java
@@ -1,5 +1,8 @@
 package com.lunchchat.domain.member.dto;
 
+import com.lunchchat.domain.user_keywords.entity.KeywordType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -12,5 +15,49 @@ public class MemberRequestDTO {
     @NotNull
     @Size(max = 3, message = "최대 3개의 관심사를 선택할 수 있습니다.")
     List<Long> interestIds;
+  }
+
+  @Getter
+  public static class UpdateKeywordDTO {
+
+    @NotNull(message = "키워드 타입은 필수입니다.")
+    private KeywordType type;
+
+    @Size(max = 5, message = "title은 공백 포함 최대 5자까지 입력 가능합니다.")
+    private String title;
+
+    @Size(max = 100, message = "description은 공백 포함 최대 100자까지 입력 가능합니다.")
+    private String description;
+  }
+
+  @Getter
+  @Schema(
+      description = "사용자 키워드 3개 입력 DTO",
+      example = """
+        {
+          "keywords": [
+            {
+              "type": "EXPRESS",
+              "title": "프로창업러",
+              "description": "상세 설명은 최대 100자"
+            },
+            {
+              "type": "GOAL",
+              "title": "교환 준비",
+              "description": "상세 설명은 최대 100자"
+            },
+            {
+              "type": "INTEREST",
+              "title": "취미 요가",
+              "description": "상세 설명은 최대 100자"
+            }
+          ]
+        }
+        """
+  )
+  public static class UpdateKeywordListDTO {
+    @Valid
+    @Size(min = 3, max = 3, message = "항상 3개의 키워드를 입력해야 합니다.")
+    private List<UpdateKeywordDTO> keywords;
   }
 }

--- a/src/main/java/com/lunchchat/domain/member/entity/Member.java
+++ b/src/main/java/com/lunchchat/domain/member/entity/Member.java
@@ -2,12 +2,14 @@ package com.lunchchat.domain.member.entity;
 
 import com.lunchchat.domain.college.entity.College;
 import com.lunchchat.domain.department.entity.Department;
+import com.lunchchat.domain.member.dto.MemberRequestDTO;
 import com.lunchchat.domain.member.entity.enums.InterestType;
 import com.lunchchat.domain.member.entity.enums.LoginType;
 import com.lunchchat.domain.member.entity.enums.MemberStatus;
 import com.lunchchat.domain.time_table.entity.TimeTable;
 import com.lunchchat.domain.university.entity.University;
 import com.lunchchat.domain.user_interests.entity.Interest;
+import com.lunchchat.domain.user_keywords.converter.UserKeywordsConverter;
 import com.lunchchat.domain.user_keywords.entity.UserKeyword;
 import com.lunchchat.global.common.BaseEntity;
 import jakarta.persistence.CascadeType;
@@ -152,6 +154,15 @@ public class Member extends BaseEntity {
 
   public void updateFcmToken(String fcmToken) {
     this.fcmToken = fcmToken;
+  }
+
+  public void clearKeywords() {
+    this.userKeywords.clear();
+  }
+
+  public void addKeywords(List<MemberRequestDTO.UpdateKeywordDTO> dtos) {
+    List<UserKeyword> converted = UserKeywordsConverter.toEntityList(this, dtos);
+    this.userKeywords.addAll(converted);
   }
 
 }

--- a/src/main/java/com/lunchchat/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberCommandService.java
@@ -1,9 +1,11 @@
 package com.lunchchat.domain.member.service;
 
+import com.lunchchat.domain.member.dto.MemberRequestDTO;
 import java.util.List;
 
 public interface MemberCommandService {
 
     void updateFcmToken(String email, String fcmToken);
     void updateInterests(String email, List<Long> interestIds);
+    void updateKeywords(String email, MemberRequestDTO.UpdateKeywordListDTO keywords);
 }

--- a/src/main/java/com/lunchchat/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberCommandServiceImpl.java
@@ -1,14 +1,18 @@
 package com.lunchchat.domain.member.service;
 
+import com.lunchchat.domain.member.dto.MemberRequestDTO;
 import com.lunchchat.domain.member.entity.Member;
 import com.lunchchat.domain.member.exception.MemberException;
 import com.lunchchat.domain.member.repository.MemberRepository;
 import com.lunchchat.domain.user_interests.entity.Interest;
 import com.lunchchat.domain.user_interests.repository.InterestRepository;
 import com.lunchchat.domain.notification.service.FcmTokenCacheService;
+import com.lunchchat.domain.user_keywords.entity.KeywordType;
+import com.lunchchat.domain.user_keywords.entity.UserKeyword;
 import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,5 +52,28 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         }
 
         member.setInterests(new HashSet<>(interests));
+    }
+
+    @Override
+    @Transactional
+    public void updateKeywords(String email, MemberRequestDTO.UpdateKeywordListDTO keywordsDto) {
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new MemberException(ErrorStatus.USER_NOT_FOUND));
+
+        List<MemberRequestDTO.UpdateKeywordDTO> keywords = keywordsDto.getKeywords();
+
+        // 중복 타입 검사
+        Set<KeywordType> types = new HashSet<>();
+        for (MemberRequestDTO.UpdateKeywordDTO dto : keywords) {
+            if (!types.add(dto.getType())) {
+                throw new MemberException(ErrorStatus.DUPLICATE_KEYWORD_TYPE);
+            }
+        }
+
+        // 기존 키워드 삭제
+        member.clearKeywords();
+
+        // 새 키워드 추가
+        member.addKeywords(keywords);
     }
 }

--- a/src/main/java/com/lunchchat/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberCommandServiceImpl.java
@@ -7,12 +7,15 @@ import com.lunchchat.domain.member.repository.MemberRepository;
 import com.lunchchat.domain.user_interests.entity.Interest;
 import com.lunchchat.domain.user_interests.repository.InterestRepository;
 import com.lunchchat.domain.notification.service.FcmTokenCacheService;
+import com.lunchchat.domain.user_keywords.converter.UserKeywordsConverter;
 import com.lunchchat.domain.user_keywords.entity.KeywordType;
 import com.lunchchat.domain.user_keywords.entity.UserKeyword;
 import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,20 +63,36 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         Member member = memberRepository.findByEmail(email)
             .orElseThrow(() -> new MemberException(ErrorStatus.USER_NOT_FOUND));
 
-        List<MemberRequestDTO.UpdateKeywordDTO> keywords = keywordsDto.getKeywords();
+        Map<KeywordType, MemberRequestDTO.UpdateKeywordDTO> requestMap =
+            keywordsDto.getKeywords().stream()
+                .peek(dto -> {
+                    if (dto.getType() == null) {
+                        throw new MemberException(ErrorStatus.KEYWORD_TYPE_REQUIRED);
+                    }
+                })
+                .collect(Collectors.toMap(MemberRequestDTO.UpdateKeywordDTO::getType, Function.identity()));
 
         // 중복 타입 검사
-        Set<KeywordType> types = new HashSet<>();
-        for (MemberRequestDTO.UpdateKeywordDTO dto : keywords) {
-            if (!types.add(dto.getType())) {
-                throw new MemberException(ErrorStatus.DUPLICATE_KEYWORD_TYPE);
-            }
+        if (requestMap.size() != keywordsDto.getKeywords().size()) {
+            throw new MemberException(ErrorStatus.DUPLICATE_KEYWORD_TYPE);
         }
 
-        // 기존 키워드 삭제
-        member.clearKeywords();
+        Map<KeywordType, UserKeyword> currentMap = member.getUserKeywords().stream()
+            .collect(Collectors.toMap(UserKeyword::getType, Function.identity()));
 
-        // 새 키워드 추가
-        member.addKeywords(keywords);
+        for (KeywordType type : KeywordType.values()) {
+            MemberRequestDTO.UpdateKeywordDTO dto = requestMap.get(type);
+            UserKeyword existing = currentMap.get(type);
+
+            if (dto != null && existing != null) { // 수정
+                existing.updateTitle(dto.getTitle());
+                existing.updateDescription(dto.getDescription());
+            } else if (dto != null) { // 새로 추가
+                UserKeyword newKeyword = UserKeywordsConverter.toEntity(member, dto);
+                member.getUserKeywords().add(newKeyword);
+            } else if (existing != null) { // 삭제
+                member.getUserKeywords().remove(existing);
+            }
+        }
     }
 }

--- a/src/main/java/com/lunchchat/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberQueryService.java
@@ -3,6 +3,7 @@ package com.lunchchat.domain.member.service;
 import com.lunchchat.domain.member.dto.MemberFilterRequestDTO;
 import com.lunchchat.domain.member.dto.MemberResponseDTO;
 
+import com.lunchchat.domain.user_keywords.dto.UserKeywordDTO;
 import java.util.List;
 
 public interface MemberQueryService {
@@ -10,4 +11,5 @@ public interface MemberQueryService {
     List<MemberResponseDTO.MemberRecommendationResponseDTO> getRecommendedMembers(Long currentMemberId);
     MemberResponseDTO.MyPageResponseDTO getMyPage(String email);
     List<MemberResponseDTO.MemberRecommendationResponseDTO> getFilteredRecommendations(String email, MemberFilterRequestDTO req);
+    List<UserKeywordDTO> getUserKeywords(String email);
 }

--- a/src/main/java/com/lunchchat/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberQueryServiceImpl.java
@@ -20,6 +20,7 @@ import com.lunchchat.domain.time_table.entity.TimeTable;
 import com.lunchchat.domain.time_table.service.TimeTableQueryService;
 import com.lunchchat.domain.user_interests.entity.Interest;
 import com.lunchchat.domain.user_interests.repository.InterestRepository;
+import com.lunchchat.domain.user_keywords.dto.UserKeywordDTO;
 import com.lunchchat.domain.user_keywords.repository.UserKeywordsRepository;
 import com.lunchchat.domain.user_statistics.entity.UserStatistics;
 import com.lunchchat.domain.user_statistics.repository.UserStatisticsRepository;
@@ -222,6 +223,17 @@ public class MemberQueryServiceImpl implements MemberQueryService {
             keywords,
             tags
         );
-      }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<UserKeywordDTO> getUserKeywords(String email) {
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new MemberException(ErrorStatus.USER_NOT_FOUND));
+
+        return userKeywordsRepository.findByMemberId(member.getId()).stream()
+            .map(UserKeywordDTO::from)
+            .collect(Collectors.toList());
+    }
 }
 

--- a/src/main/java/com/lunchchat/domain/user_keywords/converter/UserKeywordsConverter.java
+++ b/src/main/java/com/lunchchat/domain/user_keywords/converter/UserKeywordsConverter.java
@@ -1,0 +1,25 @@
+package com.lunchchat.domain.user_keywords.converter;
+
+import com.lunchchat.domain.member.dto.MemberRequestDTO;
+import com.lunchchat.domain.member.entity.Member;
+import com.lunchchat.domain.user_keywords.entity.UserKeyword;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UserKeywordsConverter {
+
+  public static UserKeyword toEntity(Member member, MemberRequestDTO.UpdateKeywordDTO dto) {
+    return UserKeyword.builder()
+        .member(member)
+        .type(dto.getType())
+        .title(dto.getTitle())
+        .description(dto.getDescription())
+        .build();
+  }
+
+  public static List<UserKeyword> toEntityList(Member member, List<MemberRequestDTO.UpdateKeywordDTO> dtos) {
+    return dtos.stream()
+        .map(dto -> toEntity(member, dto))
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/lunchchat/domain/user_keywords/entity/UserKeyword.java
+++ b/src/main/java/com/lunchchat/domain/user_keywords/entity/UserKeyword.java
@@ -3,6 +3,7 @@ package com.lunchchat.domain.user_keywords.entity;
 import com.lunchchat.domain.member.entity.Member;
 import com.lunchchat.global.common.BaseEntity;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 
 @Entity
@@ -24,10 +25,12 @@ public class UserKeyword extends BaseEntity {
     @Column(nullable = false)
     private KeywordType type;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = true, length = 100)
     private String title;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(nullable = true, columnDefinition = "TEXT")
     private String description;
 
+    public void updateTitle(String title) { this.title = title; }
+    public void updateDescription(String description) { this.description = description; }
 }

--- a/src/main/java/com/lunchchat/domain/user_keywords/entity/UserKeyword.java
+++ b/src/main/java/com/lunchchat/domain/user_keywords/entity/UserKeyword.java
@@ -8,6 +8,8 @@ import lombok.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 public class UserKeyword extends BaseEntity {
 
     @Id

--- a/src/main/java/com/lunchchat/domain/user_keywords/repository/UserKeywordsRepository.java
+++ b/src/main/java/com/lunchchat/domain/user_keywords/repository/UserKeywordsRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.repository.query.Param;
 public interface UserKeywordsRepository extends JpaRepository<UserKeyword, Long> {
   @Query("SELECT uk.title FROM UserKeyword uk WHERE uk.member.id = :memberId")
   List<String> findTitlesByMemberId(@Param("memberId") Long memberId);
+
+  List<UserKeyword> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/lunchchat/global/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/com/lunchchat/global/apiPayLoad/code/status/ErrorStatus.java
@@ -59,6 +59,10 @@ public enum ErrorStatus implements BaseErrorCode {
   INTERESTS_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "INTEREST_400", "관심사는 최대 3개까지만 선택할 수 있습니다."),
   INTERESTS_NOT_FOUND(HttpStatus.NOT_FOUND, "INTEREST_404", "선택한 관심사를 찾을 수 없습니다."),
 
+  // Keyword Error
+  KEYWORDS_COUNT_MISMATCH(HttpStatus.BAD_REQUEST, "KEYWORD_400", "키워드는 3개여야 합니다."),
+  DUPLICATE_KEYWORD_TYPE(HttpStatus.BAD_REQUEST, "KEYWORD_400_DUPLICATE", "키워드 타입이 중복되었습니다."),
+
   // Chat Error
   CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_404", "해당 채팅방이 존재하지 않습니다."),
   CANNOT_CHAT_WITH_SELF(HttpStatus.BAD_REQUEST, "CHAT_400", "자기 자신과는 채팅할 수 없습니다."),

--- a/src/main/java/com/lunchchat/global/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/com/lunchchat/global/apiPayLoad/code/status/ErrorStatus.java
@@ -62,6 +62,7 @@ public enum ErrorStatus implements BaseErrorCode {
   // Keyword Error
   KEYWORDS_COUNT_MISMATCH(HttpStatus.BAD_REQUEST, "KEYWORD_400", "키워드는 3개여야 합니다."),
   DUPLICATE_KEYWORD_TYPE(HttpStatus.BAD_REQUEST, "KEYWORD_400_DUPLICATE", "키워드 타입이 중복되었습니다."),
+  KEYWORD_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "KEYWORD_400_TYPE_REQUIRED", "키워드 타입은 필수입니다."),
 
   // Chat Error
   CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_404", "해당 채팅방이 존재하지 않습니다."),

--- a/src/main/java/com/lunchchat/global/apiPayLoad/code/status/SuccessStatus.java
+++ b/src/main/java/com/lunchchat/global/apiPayLoad/code/status/SuccessStatus.java
@@ -19,6 +19,9 @@ public enum SuccessStatus implements BaseCode {
     // 관심사 관련 응답
     INTERESTS_UPDATE_SUCCESS(HttpStatus.OK, "INTERESTS200", "관심사가 성공적으로 업데이트되었습니다."),
 
+    // 키워드 관련 응답
+    KEYWORDS_UPDATE_SUCCESS(HttpStatus.OK, "KEYWORDS200", "키워드가 성공적으로 업데이트되었습니다."),
+
     // 로그인 응답
     USER_LOGIN_OK(HttpStatus.OK, "USER200", "유저 로그인 성공"),
     USER_SIGNUP_OK(HttpStatus.OK, "USER201", "유저 회원가입 성공");

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,7 +19,7 @@ spring:
           google:
             client-id: ${CLIENT_ID}
             client-secret: ${CLIENT_SECRET}
-            redirect-uri: "https://lunchchat.kro.kr/auth/callback/google"
+            redirect-uri: "http://localhost:8080/auth/callback/google"
             scope:
               - profile
               - email

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,7 +19,7 @@ spring:
           google:
             client-id: ${CLIENT_ID}
             client-secret: ${CLIENT_SECRET}
-            redirect-uri: "http://localhost:8080/auth/callback/google"
+            redirect-uri: "https://lunchchat.kro.kr/auth/callback/google"
             scope:
               - profile
               - email

--- a/src/main/resources/db/migration/V3__Update_user_keyword_table.sql
+++ b/src/main/resources/db/migration/V3__Update_user_keyword_table.sql
@@ -1,0 +1,8 @@
+-- ============================================
+-- LunchChat V3 Database Migration Script
+-- UserKeyword 테이블 title 컬럼 nullable로 변경
+-- ============================================
+
+ALTER TABLE user_keyword MODIFY COLUMN title VARCHAR(100) NULL COMMENT '키워드 제목';
+
+SELECT 'V3 Migration for user_keyword table completed successfully' as migration_result;


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #61 

## 🔑 주요 내용

> 주요 변경점 간단 요약
#### 키워드 소개 등록 및 수정
<img width="1582" height="962" alt="image" src="https://github.com/user-attachments/assets/1e64db07-895b-4ab6-9a77-d97bf9e8f629" />
<img width="1014" height="118" alt="image" src="https://github.com/user-attachments/assets/5a26fa23-6bde-4bcc-8689-c1e96e6952ea" />

#### 내 키워드 소개 조회
<img width="1582" height="962" alt="image" src="https://github.com/user-attachments/assets/05150ff1-a4f7-48e2-ad6d-2b8337c28cd2" />

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 자신의 키워드를 등록, 수정(PATCH /keywords), 조회(GET /keywords)할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 관심 태그 수정 엔드포인트 경로가 올바르게 수정되었습니다.

* **개선 사항**
  * 키워드 입력 시 타입 중복, 개수 불일치, 타입 누락 등에 대한 상세 오류 메시지가 제공됩니다.
  * 키워드 관련 API 요청 및 응답 예시가 문서화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->