### PR TITLE
[CHORE] 빈 문자열("") URL 필터 조건에서 누락되는 문제 수정

### DIFF
--- a/src/main/java/com/lunchchat/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberQueryServiceImpl.java
@@ -200,20 +200,21 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     }
 
     private boolean isFilterMatched(Member member, MemberFilterRequestDTO req) {
-        if (req.getCollege() != null) {
+
+        if (StringUtils.hasText(req.getCollege())) {
             if (member.getCollege() == null || !req.getCollege().equals(member.getCollege().getName())) return false;
         }
 
-        if (req.getDepartment() != null) {
+        if (StringUtils.hasText(req.getDepartment())) {
             if (member.getDepartment() == null || !req.getDepartment().equals(member.getDepartment().getName())) return false;
         }
 
-        if (req.getInterest() != null) {
+        if (StringUtils.hasText(req.getInterest())) {
             if (member.getInterests() == null || member.getInterests().stream()
                     .noneMatch(i -> i.getType().name().equals(req.getInterest()))) return false;
         }
 
-        if (req.getStudentNo() != null) {
+        if (StringUtils.hasText(req.getStudentNo())) {
             String target = member.getStudentNo();
             if (target == null) return false;
 


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- ex) feat/17-profile-recommendation
## 🔑 주요 내용

- 빈 문자열("") URL 필터 조건에서 누락되는 문제 수정

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 필터 적용 시 공백이나 빈 문자열 입력이 무시되도록 개선되었습니다. 이제 필터 값이 실제로 입력된 경우에만 필터가 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->