### PR TITLE
[REFACTOR] 채팅 전송시 stomp 인증 방식 

### DIFF
--- a/src/main/java/com/lunchchat/domain/chat/config/StompHandler.java
+++ b/src/main/java/com/lunchchat/domain/chat/config/StompHandler.java
@@ -50,27 +50,13 @@ public class StompHandler implements ChannelInterceptor {
             String email = claims.get("email", String.class);
             accessor.setUser(() -> email); // Principal 설정
 
-            //사용자 정보를 websocket 연결 컨텍스트에 저장 (이후 subscribe 시에도 꺼내 쓸 수 있게)
+            //사용자 정보를 websocket 연결 컨텍스트에 저장 (이후 subscribe, send 시에도 꺼내 쓸 수 있게)
             accessor.getSessionAttributes().put("user", email);
 
             log.info("stomp 연결 성공: {}", email);
         }
 
         if (StompCommand.SUBSCRIBE.equals(command)) {
-//            String token = accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION);
-//
-//            if (!StringUtils.hasText(token) || !token.startsWith("Bearer ")) {
-//                log.warn("SUBSCRIBE 요청에 JWT 누락 또는 오류");
-//                throw new AccessDeniedException("JWT 누락 또는 오류");
-//            }
-//
-//            token = token.substring(7);
-//            if (!jwtUtil.validateToken(token)) {
-//                throw new AccessDeniedException("유효하지 않은 JWT");
-//            }
-//
-//            Claims claims = jwtUtil.parseJwt(token);
-//            String email = claims.get("email", String.class);
 
             Object user = accessor.getSessionAttributes().get("user");
             if (user != null) {

--- a/src/main/java/com/lunchchat/domain/chat/config/StompHandler.java
+++ b/src/main/java/com/lunchchat/domain/chat/config/StompHandler.java
@@ -47,26 +47,41 @@ public class StompHandler implements ChannelInterceptor {
 
             // 토큰 유효성 검증 성공 시, 사용자 정보 설정 (선택)
             Claims claims = jwtUtil.parseJwt(token);
-            accessor.setUser(() -> claims.getSubject());  // principal 설정 (email)
+            String email = claims.get("email", String.class);
+            accessor.setUser(() -> email); // Principal 설정
 
-            log.info("stomp 연결 성공");
+            //사용자 정보를 websocket 연결 컨텍스트에 저장 (이후 subscribe 시에도 꺼내 쓸 수 있게)
+            accessor.getSessionAttributes().put("user", email);
+
+            log.info("stomp 연결 성공: {}", email);
         }
 
         if (StompCommand.SUBSCRIBE.equals(command)) {
-            String token = accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION);
+//            String token = accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION);
+//
+//            if (!StringUtils.hasText(token) || !token.startsWith("Bearer ")) {
+//                log.warn("SUBSCRIBE 요청에 JWT 누락 또는 오류");
+//                throw new AccessDeniedException("JWT 누락 또는 오류");
+//            }
+//
+//            token = token.substring(7);
+//            if (!jwtUtil.validateToken(token)) {
+//                throw new AccessDeniedException("유효하지 않은 JWT");
+//            }
+//
+//            Claims claims = jwtUtil.parseJwt(token);
+//            String email = claims.get("email", String.class);
 
-            if (!StringUtils.hasText(token) || !token.startsWith("Bearer ")) {
-                log.warn("SUBSCRIBE 요청에 JWT 누락 또는 오류");
-                throw new AccessDeniedException("JWT 누락 또는 오류");
+            Object user = accessor.getSessionAttributes().get("user");
+            if (user != null) {
+                accessor.setUser(() -> (String) user);
+            } else {
+                log.warn("SUBSCRIBE 요청에 인증된 사용자 없음");
+                return null;
             }
 
-            token = token.substring(7);
-            if (!jwtUtil.validateToken(token)) {
-                throw new AccessDeniedException("유효하지 않은 JWT");
-            }
+            String email = accessor.getUser().getName(); // CONNECT 시 저장한 이메일
 
-            Claims claims = jwtUtil.parseJwt(token);
-            String email = claims.get("email", String.class);
             String destination = accessor.getDestination();  // 예: /sub/chat/room/3
 
             Long chatRoomId = extractRoomIdFromDestination(destination);

--- a/src/main/java/com/lunchchat/domain/chat/controller/ChattingController.java
+++ b/src/main/java/com/lunchchat/domain/chat/controller/ChattingController.java
@@ -2,9 +2,12 @@ package com.lunchchat.domain.chat.controller;
 
 import com.lunchchat.domain.chat.dto.request.ChatMessageReq;
 import com.lunchchat.domain.chat.service.ChatMessageService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -16,9 +19,24 @@ public class ChattingController {
     // 클라이언트로부터 채팅 메시지 받는 엔드포인트
     // prefix를 "/pub"로 설정했으므로, 실제 메시지는 "/pub/chat/{roomId}"로 전송됨
     @MessageMapping("/chat/{roomId}")
-    public void handleMessage(@DestinationVariable Long roomId, ChatMessageReq chatMessageReq) {
+    public void handleMessage(@DestinationVariable Long roomId,
+            ChatMessageReq chatMessageReq,
+            Message<?> message) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        String email = null;
+        if (accessor.getUser() != null) {
+            email = accessor.getUser().getName();
+        } else if (accessor.getSessionAttributes() != null) {
+            email = (String) accessor.getSessionAttributes().get("user");
+        }
+
+        if (email == null) {
+            throw new RuntimeException("사용자 정보 없음");
+        }
+
         // 채팅 메시지 전송
-        chatMessageService.sendMessage(roomId, chatMessageReq);
+        chatMessageService.sendMessage(roomId, email, chatMessageReq);
     }
 
 }

--- a/src/main/java/com/lunchchat/domain/chat/dto/request/ChatMessageReq.java
+++ b/src/main/java/com/lunchchat/domain/chat/dto/request/ChatMessageReq.java
@@ -1,6 +1,5 @@
 package com.lunchchat.domain.chat.dto.request;
 
 public record ChatMessageReq(
-    Long senderId,
     String content
 ) { }

--- a/src/main/java/com/lunchchat/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/lunchchat/domain/chat/service/ChatMessageService.java
@@ -26,12 +26,17 @@ public class ChatMessageService {
     private final RedisPublisher redisPublisher;
 
     // 메시지 전송 로직 구현
-    public void sendMessage(Long roomId, ChatMessageReq messageReq) {
+    public void sendMessage(Long roomId, String senderEmail, ChatMessageReq messageReq) {
 
         //user, room 불러오기 -> 유저 구현시 직접 참조로 변경
-        Long senderId = messageReq.senderId();
+//        Long senderId = messageReq.senderId();
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
+
+        Member sender = memberRepository.findByEmail(senderEmail)
+                .orElseThrow(() -> new ChatException(ErrorStatus.USER_NOT_FOUND));
+
+        Long senderId = sender.getId();
 
         //채팅방 구독 여부 검증
         if (!room.isParticipant(senderId)) {


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- ex) feat/123-login-api
- close #66 

## 🔑 주요 내용

- websocket 연결 시의 인증 정보를 기반으로 채팅 메시지 전송하도록 구현
- 초기 연결시의 사용자 정보를 websocket 세션 컨텍스트에 저장하고 불러오는 방식.

- 주요 변경점 간단 요약

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
