### PR TITLE
[FEAT] 이달의 멘토 신청 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ out/
 .vscode/
 
 local.env
-.env
+.envsrc/main/resources/sheets-key.json
+src/main/resources/sheets-key.json

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,11 @@ dependencies {
 
     //Web Flux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    //GoogleApi
+    implementation 'com.google.api-client:google-api-client:2.2.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev20230227-2.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/lunchchat/domain/match/controller/MentorController.java
+++ b/src/main/java/com/lunchchat/domain/match/controller/MentorController.java
@@ -1,5 +1,12 @@
 package com.lunchchat.domain.match.controller;
 
-public class MentoController {
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/mentor")
+public class MentorController{
+
+
 
 }

--- a/src/main/java/com/lunchchat/domain/match/controller/MentorController.java
+++ b/src/main/java/com/lunchchat/domain/match/controller/MentorController.java
@@ -1,5 +1,11 @@
 package com.lunchchat.domain.match.controller;
 
+import com.lunchchat.domain.match.dto.MentorDTO;
+import com.lunchchat.domain.match.service.MentorService;
+import com.lunchchat.global.apiPayLoad.ApiResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -7,6 +13,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/mentor")
 public class MentorController{
 
+  private final MentorService mentorService;
 
+  public MentorController(MentorService mentorService) {
+    this.mentorService = mentorService;
+  }
+
+  @PostMapping("/monthlyM")
+  public ApiResponse<String> submit(@RequestBody MentorDTO.MonthlyMentorDTO dto) {
+    mentorService.appendRow(List.of(
+        dto.phone(),
+        dto.question(),
+        dto.university(),
+        dto.email(),
+        dto.department(),
+        dto.studentNo(),
+        dto.name()
+    ));
+    return ApiResponse.onSuccess("엑셀 작성 완료");
+  }
 
 }

--- a/src/main/java/com/lunchchat/domain/match/controller/MentorController.java
+++ b/src/main/java/com/lunchchat/domain/match/controller/MentorController.java
@@ -2,8 +2,14 @@ package com.lunchchat.domain.match.controller;
 
 import com.lunchchat.domain.match.dto.MentorDTO;
 import com.lunchchat.domain.match.service.MentorService;
+import com.lunchchat.domain.member.entity.Member;
+import com.lunchchat.domain.member.repository.MemberRepository;
 import com.lunchchat.global.apiPayLoad.ApiResponse;
+import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
+import com.lunchchat.global.apiPayLoad.exception.AuthException;
+import com.lunchchat.global.security.auth.dto.CustomUserDetails;
 import java.util.List;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,22 +20,32 @@ import org.springframework.web.bind.annotation.RestController;
 public class MentorController{
 
   private final MentorService mentorService;
+  private final MemberRepository memberRepository;
 
-  public MentorController(MentorService mentorService) {
+  public MentorController(MentorService mentorService, MemberRepository memberRepository) {
     this.mentorService = mentorService;
+    this.memberRepository = memberRepository;
   }
 
   @PostMapping("/monthlyM")
-  public ApiResponse<String> submit(@RequestBody MentorDTO.MonthlyMentorDTO dto) {
+  public ApiResponse<String> submit(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestBody MentorDTO.MonthlyMentorDTO dto
+  ) {
+    String email = userDetails.getUsername();
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new AuthException(ErrorStatus.USER_NOT_FOUND));
+
     mentorService.appendRow(List.of(
         dto.phone(),
         dto.question(),
-        dto.university(),
-        dto.email(),
-        dto.department(),
-        dto.studentNo(),
-        dto.name()
+        member.getUniversity().getName(),
+        member.getEmail(),
+        member.getDepartment().getName(),
+        member.getStudentNo(),
+        member.getMembername()
     ));
+
     return ApiResponse.onSuccess("엑셀 작성 완료");
   }
 

--- a/src/main/java/com/lunchchat/domain/match/controller/MentorController.java
+++ b/src/main/java/com/lunchchat/domain/match/controller/MentorController.java
@@ -1,0 +1,5 @@
+package com.lunchchat.domain.match.controller;
+
+public class MentoController {
+
+}

--- a/src/main/java/com/lunchchat/domain/match/dto/MentorDTO.java
+++ b/src/main/java/com/lunchchat/domain/match/dto/MentorDTO.java
@@ -1,4 +1,15 @@
 package com.lunchchat.domain.match.dto;
 
-public class MentorDTO {
+public record MentorDTO() {
+
+  public record MonthlyMentorDTO(
+    String phone,
+    String question,
+    String university,
+    String email,
+    String department,
+    String studentNo,
+    String name
+  ){}
+
 }

--- a/src/main/java/com/lunchchat/domain/match/dto/MentorDTO.java
+++ b/src/main/java/com/lunchchat/domain/match/dto/MentorDTO.java
@@ -4,12 +4,7 @@ public record MentorDTO() {
 
   public record MonthlyMentorDTO(
     String phone,
-    String question,
-    String university,
-    String email,
-    String department,
-    String studentNo,
-    String name
+    String question
   ){}
 
 }

--- a/src/main/java/com/lunchchat/domain/match/dto/MentorDTO.java
+++ b/src/main/java/com/lunchchat/domain/match/dto/MentorDTO.java
@@ -1,0 +1,4 @@
+package com.lunchchat.domain.match.dto;
+
+public class MentorDTO {
+}

--- a/src/main/java/com/lunchchat/domain/match/service/MentorService.java
+++ b/src/main/java/com/lunchchat/domain/match/service/MentorService.java
@@ -1,0 +1,47 @@
+package com.lunchchat.domain.match.service;
+
+import com.google.api.services.sheets.v4.Sheets;
+import java.io.IOException;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MentorService {
+
+  private final Sheets sheets;
+
+  public MentorService(Sheets sheets) {
+    this.sheets = sheets;
+  }
+
+  @Value("${google.sheet.id}")
+  private String sheetId;
+
+  //
+  public void appendRow(List<Object> rowData) {
+    ValueRange body = createValueRange(rowData);
+    // 엑셀 내 "이달의멘토" 탭에 작성
+    writeToSheet("이달의멘토", body);
+  }
+
+  //2차원 리스트로 변경
+  private ValueRange createValueRange(List<Object> rowData) {
+    return new ValueRange()
+        .setValues(List.of(rowData));
+  }
+
+  //구글 시트에 값 추가
+  private void writeToSheet(String sheetName, ValueRange valueRange) {
+    try {
+      sheets.spreadsheets().values()
+          //!A1 = 시작점, valueRange = 데이터
+          .append(sheetId, sheetName + "!A1", valueRange)
+          .setValueInputOption("USER_ENTERED")
+          .execute();
+    } catch (IOException e) {
+      throw new RuntimeException("엑셀에 추가하지 못했습니다", e);
+    }
+  }
+}

--- a/src/main/java/com/lunchchat/global/config/security/GoogleSheetsConfig.java
+++ b/src/main/java/com/lunchchat/global/config/security/GoogleSheetsConfig.java
@@ -1,0 +1,34 @@
+package com.lunchchat.global.config.security;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.InputStream;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+public class GoogleSheetsConfig {
+
+  @Bean
+  public Sheets sheetsService() throws Exception {
+
+    // 인증파일
+    InputStream input = new ClassPathResource("sheets-key.json").getInputStream();
+
+    // 인증객체 생성
+    GoogleCredentials credentials = GoogleCredentials.fromStream(input)
+        .createScoped(List.of("https://www.googleapis.com/auth/spreadsheets"));
+
+    // 클라이언트 빌더 생성
+    return new Sheets.Builder(
+        GoogleNetHttpTransport.newTrustedTransport(),
+        JacksonFactory.getDefaultInstance(),
+        new HttpCredentialsAdapter(credentials)
+    ).setApplicationName("런치챗_이달의멘토").build();
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -54,6 +54,10 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
+google:
+  sheet:
+    id: ${GOOGLE_SHEET_ID}
+
 fcm:
   service-account-json: ${FCM_SERVICE_ACCOUNT_JSON:}
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -48,6 +48,10 @@ spring:
     redis:
       timeout: 30000ms
 
+google:
+  sheet:
+    id: ${GOOGLE_SHEET_ID}
+
 fcm:
   service-account-file: ${FCM_SERVICE_ACCOUNT_FILE:}
 


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #70 

## 🔑 주요 내용

- Excel에 연동을 하여 따로 DB를 이용하지 않고, ExcelSheets에 신청자와 신청내용이 저장되게 하였습니다!
- phone/question만 작성 받고, member 정보는 username 통해 불러옵니다.

<img width="440" height="131" alt="스크린샷 2025-08-03 오전 12 36 19" src="https://github.com/user-attachments/assets/e1a0c8f0-6964-4987-8be9-0e6162c4899a" />

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이달의 멘토 정보를 제출할 수 있는 새로운 API가 추가되었습니다.
  * 제출된 멘토 정보가 Google Sheets에 자동으로 기록됩니다.

* **환경설정**
  * Google Sheets 연동을 위한 환경설정 및 의존성이 추가되었습니다.
  * 서비스 계정 키 파일 및 시트 ID 설정이 반영되었습니다.

* **버그 수정**
  * `.gitignore` 파일의 Google Sheets 키 파일 관련 항목이 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->