### PR TITLE
[CHORE] 최신순 정렬 updatedAt필터링 수정

### DIFF
--- a/src/main/java/com/lunchchat/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/member/service/MemberQueryServiceImpl.java
@@ -164,7 +164,8 @@ public class MemberQueryServiceImpl implements MemberQueryService {
                 .filter(member -> isFilterMatched(member, req))
                 .map(member -> {
                     long matchCount = matchRepository.countMatchesByMember(member.getEmail());
-                    return new Object[]{member, matchCount, member.getUpdatedAt()};
+                    LocalDateTime updatedAt = Optional.ofNullable(member.getUpdatedAt()).orElse(LocalDateTime.MIN); // null 방어
+                    return new Object[]{member, matchCount, updatedAt};
                 })
                 .sorted((a, b) -> {
                     if ("recommend".equals(req.getSort())) {


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- ex) feat/17-profile-recommendation

## 🔑 주요 내용

- 최신순 정렬 시 updated_at이 null인 member가 있으면 에러발생.
- null인 경우 최신순 정렬 시 가장 뒤로 정렬되도록 수정

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 추천 목록 정렬 시 발생할 수 있는 null 값으로 인한 오류를 방지하여, 안정적으로 추천 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->