### PR TITLE
[BUGFIX] 매치 목록 조회 응답 수정

### DIFF
--- a/src/main/java/com/lunchchat/domain/match/controller/MatchRestController.java
+++ b/src/main/java/com/lunchchat/domain/match/controller/MatchRestController.java
@@ -8,6 +8,7 @@ import com.lunchchat.domain.match.entity.Matches;
 import com.lunchchat.domain.match.service.MatchCommandService;
 import com.lunchchat.domain.match.service.MatchQueryService;
 import com.lunchchat.global.apiPayLoad.ApiResponse;
+import com.lunchchat.global.apiPayLoad.PaginatedResponse;
 import com.lunchchat.global.security.auth.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,13 +26,14 @@ public class MatchRestController {
 
   @GetMapping
   @Operation(summary = "매치 목록 조회", description = "사용자의 매치 목록을 상태에 따라 조회합니다.")
-  public ApiResponse<MatchResponseDto.MatchListPageDto> getMatchList(
+  public ApiResponse<PaginatedResponse<MatchResponseDto.MatchListDto>> getMatchList(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @RequestParam(name = "status") MatchStatusType status,
-      @RequestParam(name = "page", defaultValue = "0") int page) {
+      @RequestParam(name = "page", defaultValue = "0") int page,
+      @RequestParam(name = "size", defaultValue = "10") int size) {
 
     String email = customUserDetails.getUsername();
-    return ApiResponse.onSuccess(matchQueryService.getMatchListDtosByStatus(status, email, page));
+    return ApiResponse.onSuccess(matchQueryService.getMatchListDtosByStatus(status, email, page, size));
   }
 
   @PostMapping

--- a/src/main/java/com/lunchchat/domain/match/converter/MatchConverter.java
+++ b/src/main/java/com/lunchchat/domain/match/converter/MatchConverter.java
@@ -7,6 +7,7 @@ import com.lunchchat.domain.member.entity.Member;
 import com.lunchchat.domain.user_interests.entity.Interest;
 import com.lunchchat.domain.user_keywords.entity.UserKeyword;
 
+import com.lunchchat.global.apiPayLoad.PaginatedResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -24,22 +25,29 @@ public class MatchConverter {
   }
 
 
-  public static MatchResponseDto.MatchListPageDto toMatchListPageDto(Page<Matches> matchPage, Long currentUserId) {
+  public static PaginatedResponse<MatchResponseDto.MatchListDto> toPaginatedMatchListDto(
+      Page<Matches> matchPage,
+      Long currentUserId
+  ) {
     List<MatchResponseDto.MatchListDto> matchList = matchPage.stream()
         .map(match -> {
           Member opponent = getOpponent(currentUserId, match);
           return toMatchListDto(match, opponent);
         })
-        .toList();
+        .collect(Collectors.toList());
 
-    return new MatchResponseDto.MatchListPageDto(
-        matchList,
-        matchList.size(),
-        matchPage.getTotalPages(),
-        matchPage.getTotalElements(),
-        matchPage.isFirst(),
-        matchPage.hasNext()
-    );
+    PaginatedResponse.Meta meta = PaginatedResponse.Meta.builder()
+        .currentPage(matchPage.getNumber())
+        .pageSize(matchPage.getSize())
+        .totalItems(matchPage.getTotalElements())
+        .totalPages(matchPage.getTotalPages())
+        .hasNext(matchPage.hasNext())
+        .build();
+
+    return PaginatedResponse.<MatchResponseDto.MatchListDto>builder()
+        .data(matchList)
+        .meta(meta)
+        .build();
   }
 
   private static MatchResponseDto.MatchedUserDto toMatchedUserDto(Member member) {

--- a/src/main/java/com/lunchchat/domain/match/dto/MatchResponseDto.java
+++ b/src/main/java/com/lunchchat/domain/match/dto/MatchResponseDto.java
@@ -24,15 +24,6 @@ public class MatchResponseDto {
         List<InterestDto> userInterests
     ) {}
 
-    public record MatchListPageDto(
-        List<MatchListDto> matchList,
-        Integer listSize,
-        Integer totalPage,
-        Long totalElements,
-        Boolean isFirst,
-        Boolean hasNext
-    ) {}
-
     public record KeywordDto(
         Long id,
         String keywordName

--- a/src/main/java/com/lunchchat/domain/match/service/MatchQueryService.java
+++ b/src/main/java/com/lunchchat/domain/match/service/MatchQueryService.java
@@ -5,11 +5,12 @@ import com.lunchchat.domain.match.dto.MatchResponseDto.MatchListDto;
 import com.lunchchat.domain.match.dto.enums.MatchStatusType;
 
 import com.lunchchat.domain.match.entity.Matches;
+import com.lunchchat.global.apiPayLoad.PaginatedResponse;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
 public interface MatchQueryService {
     Page<Matches> getMatchesByStatus(MatchStatusType status, Long memberId, PageRequest pageable);
-    MatchResponseDto.MatchListPageDto getMatchListDtosByStatus(MatchStatusType status, String email, int page);
+    PaginatedResponse<MatchResponseDto.MatchListDto> getMatchListDtosByStatus(MatchStatusType status, String email, int page, int size);
 }

--- a/src/main/java/com/lunchchat/domain/match/service/MatchQueryServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/match/service/MatchQueryServiceImpl.java
@@ -2,12 +2,14 @@ package com.lunchchat.domain.match.service;
 
 import com.lunchchat.domain.match.converter.MatchConverter;
 import com.lunchchat.domain.match.dto.MatchResponseDto;
+import com.lunchchat.domain.match.dto.MatchResponseDto.MatchListDto;
 import com.lunchchat.domain.match.dto.enums.MatchStatusType;
 import com.lunchchat.domain.match.entity.MatchStatus;
 import com.lunchchat.domain.match.entity.Matches;
 import com.lunchchat.domain.match.repository.MatchRepository;
 import com.lunchchat.domain.member.entity.Member;
 import com.lunchchat.domain.member.repository.MemberRepository;
+import com.lunchchat.global.apiPayLoad.PaginatedResponse;
 import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
 import com.lunchchat.global.apiPayLoad.exception.handler.MatchException;
 import lombok.RequiredArgsConstructor;
@@ -44,13 +46,13 @@ public class MatchQueryServiceImpl implements MatchQueryService {
 
   @Override
   @Transactional(readOnly = true)
-  public MatchResponseDto.MatchListPageDto getMatchListDtosByStatus(MatchStatusType status, String email, int page) {
+  public PaginatedResponse<MatchListDto> getMatchListDtosByStatus(MatchStatusType status, String email, int page, int size) {
     Member member = memberRepository.findByEmail(email)
         .orElseThrow(() -> new MatchException(ErrorStatus.USER_NOT_FOUND));
 
-    PageRequest pageable = PageRequest.of(page, 10);
+    PageRequest pageable = PageRequest.of(page, size);
     Page<Matches> matchPage = getMatchesByStatus(status, member.getId(), pageable);
 
-    return MatchConverter.toMatchListPageDto(matchPage, member.getId());
+    return MatchConverter.toPaginatedMatchListDto(matchPage, member.getId());
   }
 }


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

#15 

## 🔑 주요 내용

> 주요 변경점 간단 요약
- 매치 목록 조회 시 응답 메타 정보에 currentPage가 누락되어 있어 해당 값을 포함하도록 수정했습니다.
<img width="1582" height="954" alt="image" src="https://github.com/user-attachments/assets/37ae80eb-fdba-4364-ab09-6e50adee46d9" />

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매치 목록 조회 시 페이지네이션(page, size) 파라미터를 지원하여, 한 번에 불러올 항목 수를 사용자가 지정할 수 있습니다.

* **버그 수정**
  * 매치 목록 응답 구조가 표준화된 페이지네이션 응답 형식으로 개선되었습니다. 

* **기타**
  * 기존 매치 목록 응답 데이터 구조가 변경되어, 더 유연하게 페이지 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->