### PR TITLE
[FIX] 매치 목록 최신순(createdAt DESC) 정렬 적용

### DIFF
--- a/src/main/java/com/lunchchat/domain/match/service/MatchQueryServiceImpl.java
+++ b/src/main/java/com/lunchchat/domain/match/service/MatchQueryServiceImpl.java
@@ -15,6 +15,7 @@ import com.lunchchat.global.apiPayLoad.exception.handler.MatchException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,7 +51,7 @@ public class MatchQueryServiceImpl implements MatchQueryService {
     Member member = memberRepository.findByEmail(email)
         .orElseThrow(() -> new MatchException(ErrorStatus.USER_NOT_FOUND));
 
-    PageRequest pageable = PageRequest.of(page, size);
+    PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
     Page<Matches> matchPage = getMatchesByStatus(status, member.getId(), pageable);
 
     return MatchConverter.toPaginatedMatchListDto(matchPage, member.getId());


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

#15 

## 🔑 주요 내용

> 주요 변경점 간단 요약
- 매치 목록을 createdAt 기준 최신순으로 정렬되도록 수정하였습니다.

<img width="1582" height="954" alt="image" src="https://github.com/user-attachments/assets/caf2efd5-3708-4864-b64b-39ff53bfeea9" />

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 매치 목록 조회 시 생성일 기준 내림차순으로 정렬되어 최신 항목이 먼저 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->