### PR TITLE
[REFACTOR] 채팅방 조회 api 개선

### DIFF
--- a/src/main/java/com/lunchchat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/lunchchat/domain/chat/controller/ChatRoomController.java
@@ -53,18 +53,33 @@ public class ChatRoomController {
 //
 //        return ResponseEntity.ok(ApiResponse.onSuccess(chatRoomService.getChatRooms(userId)));
 //    }
+
     @GetMapping
-    @Operation(summary = "채팅방 목록 조회 (lastMessageSendAt 기준 커서 페이징)")
-    public ResponseEntity<ApiResponse<CursorPaginatedResponse<ChatRoomCardRes>>> getChatRooms(
+    @Operation(summary = "채팅방 리스트 조회")
+    public ResponseEntity<ApiResponse<PaginatedResponse<ChatRoomCardRes>>> getChatRooms(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(required = false) String cursor) {
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
 
         Long userId = userDetails.getMemberId();
 
-        CursorPaginatedResponse<ChatRoomCardRes> response = chatRoomService.getChatRooms(userId, size, cursor);
+        PaginatedResponse<ChatRoomCardRes> response = chatRoomService.getChatRooms(userId, page, size);
+
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
+
+//    @GetMapping
+//    @Operation(summary = "채팅방 목록 조회 (lastMessageSendAt 기준 커서 페이징)")
+//    public ResponseEntity<ApiResponse<CursorPaginatedResponse<ChatRoomCardRes>>> getChatRooms(
+//            @AuthenticationPrincipal CustomUserDetails userDetails,
+//            @RequestParam(defaultValue = "10") int size,
+//            @RequestParam(required = false) String cursor) {
+//
+//        Long userId = userDetails.getMemberId();
+//
+//        CursorPaginatedResponse<ChatRoomCardRes> response = chatRoomService.getChatRooms(userId, size, cursor);
+//        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+//    }
 
 
     //채팅방 퇴장

--- a/src/main/java/com/lunchchat/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/lunchchat/domain/chat/repository/ChatRoomRepository.java
@@ -5,6 +5,7 @@ import com.lunchchat.domain.member.entity.Member;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,28 +17,37 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     List<ChatRoom> findAllByStarterOrFriend(Member starter, Member friend);
 
-    @Query("""
-        SELECT r FROM ChatRoom r
-        WHERE (r.starter = :user OR r.friend = :user)
-        AND (:cursor IS NULL OR r.lastMessageSendAt < :cursor)
-        ORDER BY r.lastMessageSendAt DESC
-        """)
-    List<ChatRoom> findChatRoomsByCursor(
-            @Param("user") Member user,
-            @Param("cursor") LocalDateTime cursor,
-            Pageable pageable
-    );
+//    @Query("""
+//        SELECT r FROM ChatRoom r
+//        WHERE (r.starter = :user OR r.friend = :user)
+//        AND (:cursor IS NULL OR r.lastMessageSendAt < :cursor)
+//        ORDER BY r.lastMessageSendAt DESC
+//        """)
+//    List<ChatRoom> findChatRoomsByCursor(
+//            @Param("user") Member user,
+//            @Param("cursor") LocalDateTime cursor,
+//            Pageable pageable
+//    );
+//
+//    @Query("""
+//        SELECT r FROM ChatRoom r
+//        WHERE
+//            (r.starter = :user OR r.friend = :user)
+//            AND (:cursorTime IS NULL OR r.lastMessageSendAt < :cursorTime)
+//        ORDER BY r.lastMessageSendAt DESC
+//    """)
+//    List<ChatRoom> findByUserWithCursor(
+//            @Param("user") Member user,
+//            @Param("cursorTime") LocalDateTime cursorTime,
+//            Pageable pageable
+//    );
 
     @Query("""
-        SELECT r FROM ChatRoom r
-        WHERE 
-            (r.starter = :user OR r.friend = :user)
-            AND (:cursorTime IS NULL OR r.lastMessageSendAt < :cursorTime)
-        ORDER BY r.lastMessageSendAt DESC
-    """)
-    List<ChatRoom> findByUserWithCursor(
-            @Param("user") Member user,
-            @Param("cursorTime") LocalDateTime cursorTime,
-            Pageable pageable
-    );
+    select c from ChatRoom c
+    where (c.starter = :user and c.isExitedByStarter = false)
+       or (c.friend = :user and c.isExitedByFriend = false)
+    order by c.lastMessageSendAt desc
+""")
+    Page<ChatRoom> findActiveChatRoomsByUser(@Param("user") Member user, Pageable pageable);
+
 }

--- a/src/main/java/com/lunchchat/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/lunchchat/domain/chat/service/ChatMessageService.java
@@ -13,6 +13,7 @@ import com.lunchchat.global.apiPayLoad.code.status.ErrorStatus;
 import com.lunchchat.global.apiPayLoad.exception.handler.ChatException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +26,7 @@ public class ChatMessageService {
     private final RedisPublisher redisPublisher;
 
     // 메시지 전송 로직 구현
+    @Transactional
     public void sendMessage(Long roomId, String senderEmail, ChatMessageReq messageReq) {
 
         //user, room 불러오기 -> 유저 구현시 직접 참조로 변경

--- a/src/main/java/com/lunchchat/global/apiPayLoad/CursorPaginatedResponse.java
+++ b/src/main/java/com/lunchchat/global/apiPayLoad/CursorPaginatedResponse.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class CursorPaginatedResponse<T> {
+    private Long userId;
     private List<T> data;
     private CursorMeta meta;
 


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- ex) feat/123-login-api

## 🔑 주요 내용

- 채팅방 조회 api 페이징 방식 cursor -> offset 변경 
- 채팅방 마지막 활성화 시간 업데이트
- 응답 형식 userId 포함해 반환하도록 수정

## TODO
- 채팅방 메시지 조회 개선
- 추후 주석 제거예정

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 채팅방 목록 조회 시 페이지 기반 페이지네이션 방식이 도입되었습니다.

* **버그 수정**
  * 채팅방 목록에서 사용자가 나간 채팅방이 더 이상 표시되지 않습니다.

* **리팩터**
  * 채팅방 목록 및 메시지 조회 로직이 페이지네이션 구조로 개선되었습니다.
  * 메시지 전송 과정이 트랜잭션으로 처리되어 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->