### PR TITLE
[FIX] FCM 푸시 알림 큐 처리 실패 해결

### DIFF
--- a/src/main/java/com/lunchchat/LaunchatApplication.java
+++ b/src/main/java/com/lunchchat/LaunchatApplication.java
@@ -3,9 +3,11 @@ package com.lunchchat;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableScheduling
 public class LaunchatApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/lunchchat/domain/notification/service/NotificationQueueService.java
+++ b/src/main/java/com/lunchchat/domain/notification/service/NotificationQueueService.java
@@ -12,13 +12,13 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class NotificationQueueService {
-    
+
     private final StringRedisTemplate redisTemplate;
     private final FcmService fcmService;
     private final ObjectMapper objectMapper;
-    
+
     private static final String QUEUE_KEY = "notification-queue";
-    
+
     public void enqueue(FcmSendDto dto) {
         try {
             String jsonDto = objectMapper.writeValueAsString(dto);
@@ -27,12 +27,12 @@ public class NotificationQueueService {
             log.error("알림 큐 추가 실패 - userId: {}", dto.getUserId(), e);
         }
     }
-    
-    @Scheduled(fixedDelay = 500)
+
+    @Scheduled(fixedDelay = 200)
     public void processQueue() {
         try {
             String jsonDto = redisTemplate.opsForList().rightPop(QUEUE_KEY);
-            
+
             if (jsonDto != null) {
                 FcmSendDto dto = objectMapper.readValue(jsonDto, FcmSendDto.class);
                 fcmService.sendNotification(dto);
@@ -41,7 +41,7 @@ public class NotificationQueueService {
             log.error("큐 알림 처리 실패", e);
         }
     }
-    
+
     public long getQueueSize() {
         Long size = redisTemplate.opsForList().size(QUEUE_KEY);
         return size != null ? size : 0;


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #90 

## 🔑 주요 내용

- 원인 분석
메인 애플리케이션 클래스 LaunchatApplication에 @EnableScheduling 어노테이션이 누락되어 Spring Boot의 스케줄링 기능이 비활성화됨

- 해결
메인 애플리케이션 클래스에 @EnableScheduling 어노테이션 추가 + 스케줄링 성능 최적화를 위해 지연 시간을 500ms에서 200ms로 단축

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 애플리케이션에 스케줄링 기능이 활성화되었습니다.

* **버그 수정**
  * 알림 큐 처리 주기가 500밀리초에서 200밀리초로 단축되어 알림 처리가 더 빨라졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->