### PR TITLE
[FEAT] 매칭 수락 API를 상대방 ID 기반으로 수정

### DIFF
--- a/src/main/java/com/lunchchat/domain/match/controller/MatchRestController.java
+++ b/src/main/java/com/lunchchat/domain/match/controller/MatchRestController.java
@@ -9,6 +9,7 @@ import com.lunchchat.domain.match.service.MatchCommandService;
 import com.lunchchat.domain.match.service.MatchQueryService;
 import com.lunchchat.global.apiPayLoad.ApiResponse;
 import com.lunchchat.global.apiPayLoad.PaginatedResponse;
+import com.lunchchat.global.apiPayLoad.code.status.SuccessStatus;
 import com.lunchchat.global.security.auth.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -47,14 +48,14 @@ public class MatchRestController {
     return ApiResponse.onSuccess(MatchConverter.toMatchResultDto(match));
   }
 
-  @PatchMapping("/{matchId}/accept")
-  @Operation(summary = "매칭 수락", description = "특정 매칭 요청을 수락합니다. 수락 알림이 자동으로 전송됩니다.")
-  public ApiResponse<Void> acceptMatch(
+  @PatchMapping("/accept/{otherMemberId}")
+  @Operation(summary = "매칭 수락", description = "특정 상대 멤버의 매칭 요청을 수락합니다. 수락 알림이 자동으로 전송됩니다.")
+  public ApiResponse<SuccessStatus> acceptMatch(
           @AuthenticationPrincipal CustomUserDetails customUserDetails,
-          @Parameter(description = "매칭 ID", required = true) @PathVariable Long matchId) {
+          @Parameter(description = "상대 멤버 ID", required = true) @PathVariable Long otherMemberId) {
 
-    matchCommandService.acceptMatch(matchId, customUserDetails.getUsername());
+    matchCommandService.acceptMatch(otherMemberId, customUserDetails.getUsername());
     
-    return ApiResponse.onSuccess(null);
+    return ApiResponse.onSuccess(SuccessStatus.MATCH_REQUEST_SUCCESS);
   }
 }

--- a/src/main/java/com/lunchchat/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/lunchchat/domain/match/repository/MatchRepository.java
@@ -20,6 +20,8 @@ public interface MatchRepository extends JpaRepository<Matches, Long> {
 
     int countByFromMemberAndStatus(Member fromMember, MatchStatus status);
 
+    Optional<Matches> findByFromMemberAndToMember(Member from, Member to);
+
     @Query("""
         SELECT m FROM Matches m
         WHERE m.status = :status

--- a/src/main/java/com/lunchchat/domain/match/service/MatchCommandService.java
+++ b/src/main/java/com/lunchchat/domain/match/service/MatchCommandService.java
@@ -4,5 +4,5 @@ import com.lunchchat.domain.match.entity.Matches;
 
 public interface MatchCommandService {
   Matches requestMatch(String senderEmail, Long toMemberId);
-  void acceptMatch(Long matchId, String memberEmail);
+  void acceptMatch(Long otherMemberId, String memberEmail);
 }

--- a/src/main/java/com/lunchchat/global/apiPayLoad/code/status/SuccessStatus.java
+++ b/src/main/java/com/lunchchat/global/apiPayLoad/code/status/SuccessStatus.java
@@ -25,6 +25,9 @@ public enum SuccessStatus implements BaseCode {
     // 키워드 관련 응답
     KEYWORDS_UPDATE_SUCCESS(HttpStatus.OK, "KEYWORDS200", "키워드가 성공적으로 업데이트되었습니다."),
 
+    // 매칭 관련 응답
+    MATCH_REQUEST_SUCCESS(HttpStatus.OK, "MATCH200", "매칭 요청이 성공적으로 처리되었습니다."),
+
     // 로그인 응답
     USER_LOGIN_OK(HttpStatus.OK, "USER200", "유저 로그인 성공"),
     USER_SIGNUP_OK(HttpStatus.OK, "USER201", "유저 회원가입 성공");


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치
#15 

## 🔑 주요 내용

> 주요 변경점 간단 요약
- 기존 매칭 수락 API는 matchId를 path variable로 받아 수락 처리를 했으나 프론트측 요청으로 상대방의 memberId를 기반으로 수락하도록 수정하였습니다.
<img width="1582" height="954" alt="image" src="https://github.com/user-attachments/assets/e0176abb-f366-4729-82a3-2444278cca16" />

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매칭 요청 수락 시 성공 상태 코드와 메시지가 반환됩니다.

* **버그 수정**
  * 매칭 요청 수락 엔드포인트가 다른 회원 ID 기반으로 변경되어 더 직관적으로 이용할 수 있습니다.

* **기타**
  * 매칭 요청 수락 관련 API 응답 및 내부 처리 방식이 개선되었습니다.
  * 매칭 조회 시 요청자와 수신자 정보를 기준으로 조회할 수 있는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->