### PR TITLE
[FEAT] 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/lunchchat/global/security/auth/controller/OAuthController.java
+++ b/src/main/java/com/lunchchat/global/security/auth/controller/OAuthController.java
@@ -75,7 +75,13 @@ public class OAuthController {
   }
 
   // 로그아웃
-
+  @PostMapping("/logout")
+  public ApiResponse<?> logout(@CookieValue(name = "refresh", required = false) String refreshToken, HttpServletResponse response
+  ) {
+    log.info("✅ logout 성공");
+    googleAuthService.logout(refreshToken, response);
+    return ApiResponse.onSuccess("로그아웃 완료");
+  }
 
   //Reissue
   @Transactional

--- a/src/main/java/com/lunchchat/global/security/auth/controller/OAuthController.java
+++ b/src/main/java/com/lunchchat/global/security/auth/controller/OAuthController.java
@@ -76,6 +76,7 @@ public class OAuthController {
 
   // 로그아웃
 
+
   //Reissue
   @Transactional
   @PostMapping("/reissue")

--- a/src/main/java/com/lunchchat/global/security/auth/infra/CookieUtil.java
+++ b/src/main/java/com/lunchchat/global/security/auth/infra/CookieUtil.java
@@ -18,4 +18,13 @@ public class CookieUtil {
         .build();
   }
 
+  public static ResponseCookie deleteCookie() {
+    return ResponseCookie.from("refresh", "")
+        .httpOnly(true)
+        .secure(true)
+        .path("/")
+        .maxAge(0) // 즉시 만료
+        .sameSite("Strict")
+        .build();
+  }
 }

--- a/src/main/java/com/lunchchat/global/security/auth/service/GoogleAuthService.java
+++ b/src/main/java/com/lunchchat/global/security/auth/service/GoogleAuthService.java
@@ -162,7 +162,7 @@ public class GoogleAuthService {
     String newRefreshToken = jwtTokenProvider.generateRefreshToken(email);
 
     // 6. 토큰 rotate
-    refreshTokenRepository.rotate(email, newRefreshToken, Duration.ofDays(30));
+    refreshTokenRepository.rotate(email, refreshToken, newRefreshToken, Duration.ofDays(30));
 
     // 7. RT 전송
     ResponseCookie refreshCookie = CookieUtil.createCookie(newRefreshToken, Duration.ofDays(30));

--- a/src/main/java/com/lunchchat/global/security/auth/service/GoogleAuthService.java
+++ b/src/main/java/com/lunchchat/global/security/auth/service/GoogleAuthService.java
@@ -237,4 +237,33 @@ public class GoogleAuthService {
     memberRepository.save(member);
   }
 
+  public void logout(String refreshToken, HttpServletResponse response) {
+    //쿠키 값 확인
+    if (refreshToken == null || refreshToken.isBlank()) {
+      response.addHeader("Set-Cookie", CookieUtil.deleteCookie().toString());
+      return;
+    }
+
+    //토큰 유효성 검사
+    try {
+      if (!jwtUtil.validateToken(refreshToken)) {
+        response.addHeader("Set-Cookie", CookieUtil.deleteCookie().toString());
+        return;
+      }
+
+      Claims claims = jwtUtil.parseJwt(refreshToken);
+      String email = jwtUtil.getEmail(claims);
+
+      // 요청이 온다면 일단 삭제(일치여부와 상관없이)
+      if (refreshTokenRepository.isValid(email, refreshToken)) {
+        refreshTokenRepository.deleteByToken(refreshToken);
+      } else {
+        refreshTokenRepository.deleteByToken(refreshToken);
+      }
+    } catch (Exception e) {
+      log.warn("🚨로그아웃 실패: {}", e.getMessage());
+    } finally {
+      response.addHeader("Set-Cookie", CookieUtil.deleteCookie().toString());
+    }
+  }
 }

--- a/src/main/java/com/lunchchat/global/security/jwt/redis/RedisRefreshTokenRepository.java
+++ b/src/main/java/com/lunchchat/global/security/jwt/redis/RedisRefreshTokenRepository.java
@@ -9,7 +9,10 @@ import org.springframework.stereotype.Repository;
 public class RedisRefreshTokenRepository implements RefreshTokenRepository {
 
   private final RedisTemplate<String, Object> redisTemplate;
+
+  //Refresh:<email> -> Token
   private static final String PREFIX = "Refresh:";
+  //RefreshIDX:<token> -> email
   private static final String IDX = "RefreshIdx:";
 
   public RedisRefreshTokenRepository(RedisTemplate<String, Object> redisTemplate) {
@@ -20,8 +23,7 @@ public class RedisRefreshTokenRepository implements RefreshTokenRepository {
   @Override
   public void save(String key, String token, Duration ttl) {
     redisTemplate.opsForValue().set(PREFIX + key, token, ttl);
-    //역인덱스
-    redisTemplate.opsForValue().set(IDX+token,key,ttl);
+    redisTemplate.opsForValue().set(IDX + token, key, ttl);
   }
 
   //RT Redis에서 조회
@@ -31,15 +33,25 @@ public class RedisRefreshTokenRepository implements RefreshTokenRepository {
     return Optional.ofNullable(value).map(Object::toString);
   }
 
-  //RT Redis에서 조회
+  //RT Request와 Redis 비교
   @Override
-  public void delete(String key) {
-    String token = (String) redisTemplate.opsForValue().get(PREFIX + key);
-    redisTemplate.delete(PREFIX + key);
-    if (token != null) redisTemplate.delete(IDX + token);
+  public boolean isValid(String key, String token) {
+    return findByKey(key).map(saved -> saved.equals(token)).orElse(false);
   }
 
-  //RT Redis에서 삭제
+  //RT 삭제(email 기반)
+  @Override
+  public void delete(String key) {
+    Object val = redisTemplate.opsForValue().get(PREFIX + key);
+    String token = (val != null) ? val.toString() : null;
+
+    redisTemplate.delete(PREFIX + key);
+    if (token != null && !token.isBlank()) {
+      redisTemplate.delete(IDX + token);
+    }
+  }
+
+  //RT 삭제(token 기반)
   @Override
   public void deleteByToken(String token) {
     Object key = redisTemplate.opsForValue().get(IDX + token);
@@ -47,16 +59,14 @@ public class RedisRefreshTokenRepository implements RefreshTokenRepository {
     redisTemplate.delete(IDX + token);
   }
 
-  //RT Request와 Redis 비교
-  @Override
-  public boolean isValid(String key, String token) {
-    return findByKey(key).map(saved -> saved.equals(token)).orElse(false);
-  }
-
   //RT rotation
   @Override
-  public void rotate(String key, String newToken, Duration ttl){
-    save(key, newToken, ttl);
-  }
+  public void rotate(String key, String oldToken, String newToken, Duration ttl){
+    if(oldToken!=null && !oldToken.isBlank()){
+      redisTemplate.delete(IDX+oldToken);
+    }
+    redisTemplate.opsForValue().set(PREFIX + key, newToken, ttl);
+    redisTemplate.opsForValue().set(IDX + newToken, key, ttl);
+    }
 
 }

--- a/src/main/java/com/lunchchat/global/security/jwt/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/lunchchat/global/security/jwt/redis/RefreshTokenRepository.java
@@ -10,6 +10,6 @@ public interface RefreshTokenRepository {
   void delete(String key);
   void deleteByToken(String token);
   boolean isValid(String key, String token);
-  void rotate(String key,String newToken, Duration ttl);
+  void rotate(String key,String oldToken,String newToken, Duration ttl);
 
 }

--- a/src/main/java/com/lunchchat/global/security/jwt/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/lunchchat/global/security/jwt/redis/RefreshTokenRepository.java
@@ -8,6 +8,7 @@ public interface RefreshTokenRepository {
   void save(String key, String token, Duration ttl);
   Optional<String> findByKey(String key);
   void delete(String key);
+  void deleteByToken(String token);
   boolean isValid(String key, String token);
   void rotate(String key,String newToken, Duration ttl);
 


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #97 

## 🔑 주요 내용

- 단일 세션에서의 로그아웃 기능을 구현했습니다
- Redis를 조회해 Refresh토큰을 삭제하는 것으로 회원 로그아웃이 이뤄집니다.
- 
<img width="672" height="532" alt="스크린샷 2025-08-11 오전 12 46 27" src="https://github.com/user-attachments/assets/e16a46d7-debc-4b23-b5b2-dfed4d302ecd" />


## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
