### PR TITLE
[REFACTOR] InterestType enum에 GPA_MANAGEMENT 추가 및 ETC 제거

### DIFF
--- a/src/main/java/com/lunchchat/domain/member/entity/enums/InterestType.java
+++ b/src/main/java/com/lunchchat/domain/member/entity/enums/InterestType.java
@@ -5,8 +5,8 @@ public enum InterestType {
     EMPLOYMENT_CAREER, // 취업/진로
     EXAM_PREPARATION, // 고시준비
     STARTUP, // 창업
+    GPA_MANAGEMENT, // 학점 관리
     FOREIGN_LANGUAGE_STUDY, // 외국어 공부
     HOBBY_LEISURE, // 취미/여가
-    SCHOOL_LIFE, // 학교생활
-    ETC // 기타
+    SCHOOL_LIFE // 학교생활
 }

--- a/src/main/resources/db/migration/V4__Update_interest_data.sql
+++ b/src/main/resources/db/migration/V4__Update_interest_data.sql
@@ -1,0 +1,53 @@
+-- ============================================
+-- InterestType enum 순서에 맞게 interest 테이블 데이터 수정
+-- ============================================
+
+-- 외래키 제약조건 임시 비활성화
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- 트랜잭션 시작
+START TRANSACTION;
+
+-- 1. 현재 interest 테이블의 id 값들을 변수에 저장
+SET @foreign_language_id = (SELECT id FROM interest WHERE type = 'FOREIGN_LANGUAGE_STUDY');
+SET @hobby_leisure_id = (SELECT id FROM interest WHERE type = 'HOBBY_LEISURE');
+SET @school_life_id = (SELECT id FROM interest WHERE type = 'SCHOOL_LIFE');
+SET @etc_id = (SELECT id FROM interest WHERE type = 'ETC');
+
+-- 2. ETC 관련 데이터 삭제
+DELETE FROM member_interest WHERE interest_id = @etc_id;
+DELETE FROM interest WHERE type = 'ETC';
+
+-- 3. 기존 데이터들을 안전한 임시 id로 이동
+-- member_interest 참조 업데이트
+UPDATE member_interest SET interest_id = 1005 WHERE interest_id = @foreign_language_id;
+UPDATE member_interest SET interest_id = 1006 WHERE interest_id = @hobby_leisure_id;
+UPDATE member_interest SET interest_id = 1007 WHERE interest_id = @school_life_id;
+
+-- interest 테이블 id 임시 변경
+UPDATE interest SET id = 1005 WHERE id = @foreign_language_id;
+UPDATE interest SET id = 1006 WHERE id = @hobby_leisure_id;
+UPDATE interest SET id = 1007 WHERE id = @school_life_id;
+
+-- 4. GPA_MANAGEMENT 추가 (AUTO_INCREMENT 비활성화 후 수동 삽입)
+ALTER TABLE interest AUTO_INCREMENT = 1;
+INSERT INTO interest (id, type, created_at, updated_at) VALUES (5, 'GPA_MANAGEMENT', NOW(), NOW());
+
+-- 5. 최종 id로 재정렬
+UPDATE interest SET id = 6 WHERE id = 1005;  -- FOREIGN_LANGUAGE_STUDY
+UPDATE interest SET id = 7 WHERE id = 1006;  -- HOBBY_LEISURE  
+UPDATE interest SET id = 8 WHERE id = 1007;  -- SCHOOL_LIFE
+
+-- 6. member_interest 테이블의 참조 id 최종 업데이트
+UPDATE member_interest SET interest_id = 6 WHERE interest_id = 1005;
+UPDATE member_interest SET interest_id = 7 WHERE interest_id = 1006;
+UPDATE member_interest SET interest_id = 8 WHERE interest_id = 1007;
+
+-- 7. AUTO_INCREMENT 값 재설정
+ALTER TABLE interest AUTO_INCREMENT = 9;
+
+-- 트랜잭션 커밋
+COMMIT;
+
+-- 외래키 제약조건 재활성화
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

#32 

## 🔑 주요 내용

> 주요 변경점 간단 요약
- 프론트 요청에 따라 `InterestType` enum에서 `ETC` 제거 및 `GPA_MANAGEMENT`(학점 관리) 추가
- main 브랜치 머지 전에 배포 DB `interest` 테이블의 데이터도 동일하게 수정 예정
<img width="1582" height="954" alt="image" src="https://github.com/user-attachments/assets/c29c3d62-46a8-4ed6-9664-37cf9df0d85f" />

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 관심사 옵션이 업데이트되었습니다: ‘GPA 관리’가 새로 추가되고 ‘기타’는 제거되었습니다.
  * 옵션 순서가 조정되어 ‘GPA 관리’가 ‘외국어 공부’ 앞에 표시되며, ‘학교생활’이 마지막으로 이동합니다.
* **기타**
  * 기존 회원의 관심사 연동과 표시가 새로운 옵션 구성에 맞게 자동으로 조정되었습니다. 필요한 경우 프로필에서 선택을 변경하세요.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->