### PR TITLE
[FEAT] 모니터링 재구축 및 디코 웹훅 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,6 +184,13 @@ env:
       echo "✅ Prometheus 설정 파일 생성 완료"
     fi
     
+    if [ -f "alertmanager/alertmanager.yml.template" ]; then
+      source .env
+      export DISCORD_WEBHOOK_URL
+      envsubst < alertmanager/alertmanager.yml.template > alertmanager/alertmanager.yml
+      echo "✅ Alertmanager 설정 파일 생성 완료"
+    fi
+    
     docker-compose up -d
     
     sleep 30

--- a/monitoring/alertmanager/alertmanager.yml.template
+++ b/monitoring/alertmanager/alertmanager.yml.template
@@ -3,7 +3,7 @@ global:
 route:
   group_by: ['alertname', 'instance']
   group_wait: 10s
-  group_interval: 10s
+  group_interval: 5m
   repeat_interval: 1h
   receiver: 'default'
   routes:
@@ -12,7 +12,7 @@ route:
       receiver: 'critical-alerts'
       group_wait: 0s
       repeat_interval: 5m
-    
+
     - match:
         severity: warning
       receiver: 'warning-alerts'
@@ -61,12 +61,12 @@ receivers:
 inhibit_rules:
   - source_match:
       alertname: 'InstanceDown'
-    target_match_re:
-      instance: '.*'
+    target_match:
+      severity: 'warning'
     equal: ['instance']
 
   - source_match:
       alertname: 'ApplicationDown'
-    target_match_re:
-      alertname: 'High.*'
+    target_match:
+      severity: 'warning'
     equal: ['instance']

--- a/monitoring/alertmanager/alertmanager.yml.template
+++ b/monitoring/alertmanager/alertmanager.yml.template
@@ -1,0 +1,72 @@
+global:
+
+route:
+  group_by: ['alertname', 'instance']
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 1h
+  receiver: 'default'
+  routes:
+    - match:
+        severity: critical
+      receiver: 'critical-alerts'
+      group_wait: 0s
+      repeat_interval: 5m
+    
+    - match:
+        severity: warning
+      receiver: 'warning-alerts'
+      group_interval: 5m
+
+receivers:
+  - name: 'default'
+    discord_configs:
+      - webhook_url: '${DISCORD_WEBHOOK_URL}'
+        title: '📊 LunchChat 모니터링 알림'
+        message: |
+          {{ range .Alerts }}
+          **Alert:** {{ .Annotations.summary }}
+          **Description:** {{ .Annotations.description }}
+          **Severity:** {{ .Labels.severity }}
+          **Instance:** {{ .Labels.instance }}
+          **Time:** <t:{{ .StartsAt.Unix }}:R>
+          {{ end }}
+
+  - name: 'critical-alerts'
+    discord_configs:
+      - webhook_url: '${DISCORD_WEBHOOK_URL}'
+        title: '🚨 CRITICAL: LunchChat 시스템 장애'
+        message: |
+          @everyone 🚨 **CRITICAL ALERT** 🚨
+          {{ range .Alerts }}
+          **Alert:** {{ .Annotations.summary }}
+          **Description:** {{ .Annotations.description }}
+          **Instance:** {{ .Labels.instance }}
+          **Started At:** <t:{{ .StartsAt.Unix }}:F>
+          {{ end }}
+
+  - name: 'warning-alerts'
+    discord_configs:
+      - webhook_url: '${DISCORD_WEBHOOK_URL}'
+        title: '⚠️ LunchChat 모니터링 경고'
+        message: |
+          {{ range .Alerts }}
+          ⚠️ **WARNING**
+          **Alert:** {{ .Annotations.summary }}
+          **Description:** {{ .Annotations.description }}
+          **Instance:** {{ .Labels.instance }}
+          **Time:** <t:{{ .StartsAt.Unix }}:R>
+          {{ end }}
+
+inhibit_rules:
+  - source_match:
+      alertname: 'InstanceDown'
+    target_match_re:
+      instance: '.*'
+    equal: ['instance']
+
+  - source_match:
+      alertname: 'ApplicationDown'
+    target_match_re:
+      alertname: 'High.*'
+    equal: ['instance']

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -16,9 +16,9 @@ services:
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
       - '--storage.tsdb.retention.time=30d'
-      - '--storage.tsdb.retention.size=5GB'
-      - '--query.max-concurrency=20'
-      - '--query.max-samples=50000000'
+      - '--storage.tsdb.retention.size=20GB'
+      - '--query.max-concurrency=10'
+      - '--query.max-samples=5000000'
       - '--web.max-connections=512'
       - '--storage.tsdb.wal-compression'
       - '--storage.tsdb.min-block-duration=2h'
@@ -59,10 +59,7 @@ services:
       - GF_LOG_LEVEL=warn
       - GF_DATABASE_MAX_OPEN_CONN=20
       - GF_DATABASE_MAX_IDLE_CONN=5
-      - GF_ALERTING_ENABLED=true
-      - GF_UNIFIED_ALERTING_ENABLED=true
       - GF_FEATURE_TOGGLES_ENABLE=alertingBigTransactions
-      - GF_PANELS_DISABLE_SANITIZE_HTML=true
       - GF_RENDERING_SERVER_URL=""
       - GF_RENDERING_CALLBACK_URL=""
     deploy:
@@ -91,13 +88,12 @@ services:
       - '--path.procfs=/host/proc'
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc|var/lib/docker/.+)($$|/)'
       - '--collector.systemd'
       - '--collector.processes'
       - '--collector.tcpstat'
       - '--collector.conntrack'
       - '--collector.cpu.info'
-      - '--collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -15,20 +15,25 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention.time=7d'
-      - '--storage.tsdb.retention.size=500MB'
-      - '--query.max-concurrency=4'
-      - '--query.max-samples=10000'
-      - '--web.max-connections=128'
+      - '--storage.tsdb.retention.time=30d'
+      - '--storage.tsdb.retention.size=5GB'
+      - '--query.max-concurrency=20'
+      - '--query.max-samples=50000000'
+      - '--web.max-connections=512'
+      - '--storage.tsdb.wal-compression'
+      - '--storage.tsdb.min-block-duration=2h'
+      - '--storage.tsdb.max-block-duration=24h'
       - '--web.enable-lifecycle'
       - '--web.route-prefix=/'
       - '--web.external-url=http://localhost:${PROMETHEUS_PORT}'
     deploy:
       resources:
         limits:
-          memory: 300M
+          memory: 2G
+          cpus: '1.0'
         reservations:
-          memory: 200M
+          memory: 1G
+          cpus: '0.5'
     networks:
       - monitoring
     user: "65534:65534"
@@ -51,19 +56,23 @@ services:
       - GF_SECURITY_COOKIE_SAMESITE=lax
       - GF_ANALYTICS_REPORTING_ENABLED=false
       - GF_ANALYTICS_CHECK_FOR_UPDATES=false
-      - GF_LOG_LEVEL=error
-      - GF_DATABASE_MAX_OPEN_CONN=5
-      - GF_DATABASE_MAX_IDLE_CONN=2
-      - GF_ALERTING_ENABLED=false
-      - GF_UNIFIED_ALERTING_ENABLED=false
+      - GF_LOG_LEVEL=warn
+      - GF_DATABASE_MAX_OPEN_CONN=20
+      - GF_DATABASE_MAX_IDLE_CONN=5
+      - GF_ALERTING_ENABLED=true
+      - GF_UNIFIED_ALERTING_ENABLED=true
+      - GF_FEATURE_TOGGLES_ENABLE=alertingBigTransactions
+      - GF_PANELS_DISABLE_SANITIZE_HTML=true
       - GF_RENDERING_SERVER_URL=""
       - GF_RENDERING_CALLBACK_URL=""
     deploy:
       resources:
         limits:
-          memory: 150M
+          memory: 512M
+          cpus: '0.5'
         reservations:
-          memory: 100M
+          memory: 256M
+          cpus: '0.25'
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
@@ -83,14 +92,12 @@ services:
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
-      - '--web.disable-exporter-metrics'
-      - '--collector.disable-defaults'
-      - '--collector.cpu'
-      - '--collector.meminfo'
-      - '--collector.diskstats'
-      - '--collector.filesystem'
-      - '--collector.loadavg'
-      - '--collector.netdev'
+      - '--collector.systemd'
+      - '--collector.processes'
+      - '--collector.tcpstat'
+      - '--collector.conntrack'
+      - '--collector.cpu.info'
+      - '--collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
@@ -102,9 +109,11 @@ services:
     deploy:
       resources:
         limits:
-          memory: 30M
+          memory: 128M
+          cpus: '0.1'
         reservations:
-          memory: 20M
+          memory: 64M
+          cpus: '0.05'
 
   redis-exporter:
     image: oliver006/redis_exporter:latest
@@ -122,9 +131,54 @@ services:
     deploy:
       resources:
         limits:
-          memory: 20M
+          memory: 64M
+          cpus: '0.1'
         reservations:
-          memory: 15M
+          memory: 32M
+          cpus: '0.05'
+
+  pushgateway:
+    image: prom/pushgateway:latest
+    container_name: ${PROJECT_NAME}_pushgateway
+    restart: unless-stopped
+    ports:
+      - "${PUSHGATEWAY_PORT}:9091"
+    networks:
+      - monitoring
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          cpus: '0.2'
+        reservations:
+          memory: 64M
+          cpus: '0.1'
+
+  # Alertmanager (알림 관리)
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: ${PROJECT_NAME}_alertmanager
+    restart: unless-stopped
+    ports:
+      - "${ALERTMANAGER_PORT:-9093}:9093"
+    volumes:
+      - ./alertmanager:/etc/alertmanager:ro
+      - alertmanager_data:/alertmanager
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+      - '--web.external-url=http://localhost:${ALERTMANAGER_PORT:-9093}'
+      - '--cluster.listen-address=0.0.0.0:9094'
+    networks:
+      - monitoring
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          cpus: '0.2'
+        reservations:
+          memory: 64M
+          cpus: '0.1'
 
 networks:
   monitoring:
@@ -134,4 +188,6 @@ volumes:
   prometheus_data:
     driver: local
   grafana_data:
+    driver: local
+  alertmanager_data:
     driver: local

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -154,7 +154,6 @@ services:
           memory: 64M
           cpus: '0.1'
 
-  # Alertmanager (알림 관리)
   alertmanager:
     image: prom/alertmanager:latest
     container_name: ${PROJECT_NAME}_alertmanager

--- a/monitoring/grafana/dashboards/spring-boot-monitoring.json
+++ b/monitoring/grafana/dashboards/spring-boot-monitoring.json
@@ -67,7 +67,7 @@
               }
             ]
           },
-          "unit": "percent"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -88,13 +88,269 @@
           "mode": "single"
         }
       },
-      "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "jvm_memory_used_bytes{job=\"lunchchat-via-nginx\"} / jvm_memory_max_bytes{job=\"lunchchat-via-nginx\"} * 100",
+          "expr": "sum(rate(http_requests_total[5m])) by (instance)",
           "interval": "",
-          "legendFormat": "{{server_name}} - {{area}} Memory Usage",
+          "legendFormat": "{{instance}} Request Rate",
           "refId": "A"
+        }
+      ],
+      "title": "Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, instance))",
+          "interval": "",
+          "legendFormat": "{{instance}} 95th Percentile",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, instance))",
+          "interval": "",
+          "legendFormat": "{{instance}} 50th Percentile",
+          "refId": "B"
+        }
+      ],
+      "title": "Response Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) by (instance) / sum(rate(http_requests_total[5m])) by (instance) * 100",
+          "interval": "",
+          "legendFormat": "{{instance}} Error Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{area=\"heap\"}",
+          "interval": "",
+          "legendFormat": "{{instance}} Heap Used",
+          "refId": "A"
+        },
+        {
+          "expr": "jvm_memory_max_bytes{area=\"heap\"}",
+          "interval": "",
+          "legendFormat": "{{instance}} Heap Max",
+          "refId": "B"
         }
       ],
       "title": "JVM Memory Usage",
@@ -149,89 +405,7 @@
               }
             ]
           },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "pluginVersion": "8.0.0",
-      "targets": [
-        {
-          "expr": "rate(http_server_requests_seconds_count{job=\"lunchchat-via-nginx\"}[5m])",
-          "interval": "",
-          "legendFormat": "{{server_name}} - {{method}} {{uri}}",
-          "refId": "A"
-        }
-      ],
-      "title": "HTTP Request Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "vis": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -239,9 +413,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 16
       },
-      "id": 3,
+      "id": 5,
       "options": {
         "legend": {
           "calcs": [],
@@ -252,22 +426,21 @@
           "mode": "single"
         }
       },
-      "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "rate(http_server_requests_seconds_sum{job=\"lunchchat-via-nginx\"}[5m]) / rate(http_server_requests_seconds_count{job=\"lunchchat-via-nginx\"}[5m]) * 1000",
+          "expr": "redis_connected_clients",
           "interval": "",
-          "legendFormat": "{{server_name}} - 95th percentile",
+          "legendFormat": "Redis Connected Clients",
           "refId": "A"
         },
         {
-          "expr": "rate(http_server_requests_seconds_sum{job=\"lunchchat-via-nginx\"}[5m]) / rate(http_server_requests_seconds_count{job=\"lunchchat-via-nginx\"}[5m]) * 1000",
+          "expr": "redis_keyspace_hits_total / (redis_keyspace_hits_total + redis_keyspace_misses_total) * 100",
           "interval": "",
-          "legendFormat": "{{server_name}} - 50th percentile",
+          "legendFormat": "Redis Hit Rate (%)",
           "refId": "B"
         }
       ],
-      "title": "HTTP Response Time",
+      "title": "Redis Metrics",
       "type": "timeseries"
     },
     {
@@ -327,9 +500,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 16
       },
-      "id": 4,
+      "id": 6,
       "options": {
         "legend": {
           "calcs": [],
@@ -340,26 +513,21 @@
           "mode": "single"
         }
       },
-      "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "hikaricp_connections{job=\"lunchchat-via-nginx\"}",
+          "expr": "up{job=~\"lunchchat.*\"}",
           "interval": "",
-          "legendFormat": "{{server_name}} - {{pool}} {{state}} connections",
+          "legendFormat": "{{job}} - {{instance}} Status",
           "refId": "A"
         }
       ],
-      "title": "Database Connection Pool",
+      "title": "Service Status",
       "type": "timeseries"
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 27,
   "style": "dark",
-  "tags": [
-    "lunchchat",
-    "spring-boot"
-  ],
+  "tags": ["application", "spring-boot", "lunchchat"],
   "templating": {
     "list": []
   },
@@ -369,7 +537,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "LunchChat Spring Boot Monitoring",
-  "uid": "lunchchat_spring_boot_monitoring",
+  "title": "LunchChat Application Monitoring",
+  "uid": "lunchchat-application",
   "version": 1
 }

--- a/monitoring/grafana/dashboards/spring-boot-monitoring.json
+++ b/monitoring/grafana/dashboards/spring-boot-monitoring.json
@@ -90,7 +90,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total[5m])) by (instance)",
+          "expr": "sum(rate(http_server_requests_seconds_count[5m])) by (instance)",
           "interval": "",
           "legendFormat": "{{instance}} Request Rate",
           "refId": "A"
@@ -171,13 +171,13 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, instance))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket[5m])) by (le, instance))",
           "interval": "",
           "legendFormat": "{{instance}} 95th Percentile",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, instance))",
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_requests_seconds_bucket[5m])) by (le, instance))",
           "interval": "",
           "legendFormat": "{{instance}} 50th Percentile",
           "refId": "B"
@@ -260,7 +260,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) by (instance) / sum(rate(http_requests_total[5m])) by (instance) * 100",
+          "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[5m])) by (instance) / sum(rate(http_server_requests_seconds_count[5m])) by (instance) * 100",
           "interval": "",
           "legendFormat": "{{instance}} Error Rate",
           "refId": "A"
@@ -434,7 +434,7 @@
           "refId": "A"
         },
         {
-          "expr": "redis_keyspace_hits_total / (redis_keyspace_hits_total + redis_keyspace_misses_total) * 100",
+          "expr": "rate(redis_keyspace_hits_total[5m]) / (rate(redis_keyspace_hits_total[5m]) + rate(redis_keyspace_misses_total[5m])) * 100",
           "interval": "",
           "legendFormat": "Redis Hit Rate (%)",
           "refId": "B"

--- a/monitoring/grafana/dashboards/system-monitoring.json
+++ b/monitoring/grafana/dashboards/system-monitoring.json
@@ -54,6 +54,8 @@
             }
           },
           "mappings": [],
+          "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -88,12 +90,11 @@
           "mode": "single"
         }
       },
-      "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "100 - (avg by (instance) (irate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+          "expr": "100 - (avg by(instance) (irate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
           "interval": "",
-          "legendFormat": "CPU Usage",
+          "legendFormat": "{{instance}} CPU Usage",
           "refId": "A"
         }
       ],
@@ -136,6 +137,8 @@
             }
           },
           "mappings": [],
+          "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -145,7 +148,7 @@
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 85
               }
             ]
           },
@@ -170,12 +173,11 @@
           "mode": "single"
         }
       },
-      "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes) * 100",
+          "expr": "(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100",
           "interval": "",
-          "legendFormat": "Memory Usage",
+          "legendFormat": "{{instance}} Memory Usage",
           "refId": "A"
         }
       ],
@@ -218,6 +220,8 @@
             }
           },
           "mappings": [],
+          "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -227,7 +231,7 @@
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 90
               }
             ]
           },
@@ -252,12 +256,11 @@
           "mode": "single"
         }
       },
-      "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "((node_filesystem_size_bytes{fstype!=\"tmpfs\"} - node_filesystem_free_bytes{fstype!=\"tmpfs\"}) / node_filesystem_size_bytes{fstype!=\"tmpfs\"}) * 100",
+          "expr": "(node_filesystem_size_bytes{fstype!=\"tmpfs\"} - node_filesystem_avail_bytes{fstype!=\"tmpfs\"}) / node_filesystem_size_bytes{fstype!=\"tmpfs\"} * 100",
           "interval": "",
-          "legendFormat": "Disk Usage - {{mountpoint}}",
+          "legendFormat": "{{instance}} {{mountpoint}} Disk Usage",
           "refId": "A"
         }
       ],
@@ -313,7 +316,7 @@
               }
             ]
           },
-          "unit": "binBps"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -334,29 +337,27 @@
           "mode": "single"
         }
       },
-      "pluginVersion": "8.0.0",
       "targets": [
         {
           "expr": "irate(node_network_receive_bytes_total{device!=\"lo\"}[5m])",
           "interval": "",
-          "legendFormat": "Receive - {{device}}",
+          "legendFormat": "{{instance}} {{device}} RX",
           "refId": "A"
         },
         {
           "expr": "irate(node_network_transmit_bytes_total{device!=\"lo\"}[5m])",
           "interval": "",
-          "legendFormat": "Transmit - {{device}}",
+          "legendFormat": "{{instance}} {{device}} TX",
           "refId": "B"
         }
       ],
-      "title": "Network Traffic",
+      "title": "Network I/O",
       "type": "timeseries"
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 27,
   "style": "dark",
-  "tags": [],
+  "tags": ["system", "monitoring", "lunchchat"],
   "templating": {
     "list": []
   },
@@ -366,7 +367,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "System Monitoring Dashboard",
-  "uid": "system_monitoring",
+  "title": "LunchChat System Monitoring",
+  "uid": "lunchchat-system",
   "version": 1
 }

--- a/monitoring/prometheus/prometheus.yml.template
+++ b/monitoring/prometheus/prometheus.yml.template
@@ -2,10 +2,11 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
   scrape_timeout: 10s
-  query_log_file: /prometheus/queries.log
   external_labels:
     cluster: 'lunchchat'
     environment: '${MONITORING_ENVIRONMENT}'
+
+query_log_file: /prometheus/queries.log
 
 rule_files:
   - "rules/*.yml"

--- a/monitoring/prometheus/prometheus.yml.template
+++ b/monitoring/prometheus/prometheus.yml.template
@@ -1,7 +1,8 @@
 global:
-  scrape_interval: 30s
-  evaluation_interval: 30s
+  scrape_interval: 15s
+  evaluation_interval: 15s
   scrape_timeout: 10s
+  query_log_file: /prometheus/queries.log
   external_labels:
     cluster: 'lunchchat'
     environment: '${MONITORING_ENVIRONMENT}'
@@ -17,16 +18,17 @@ scrape_configs:
           service: 'prometheus'
           server_name: 'monitoring'
     metrics_path: /metrics
-    scrape_interval: 30s
+    scrape_interval: 15s
 
-  - job_name: 'loadbalancer-system'
+  - job_name: 'monitoring-server-system'
     static_configs:
       - targets: ['node-exporter:9100']
         labels:
-          server_role: 'loadbalancer'
-          server_name: 'loadbalancer'
+          server_role: 'monitoring'
+          server_name: 'monitoring-server'
+          instance: 'monitoring-server'
     metrics_path: /metrics
-    scrape_interval: 30s
+    scrape_interval: 15s
 
   - job_name: 'redis'
     static_configs:
@@ -34,8 +36,9 @@ scrape_configs:
         labels:
           service: 'redis'
           server_name: 'loadbalancer'
+          instance: 'redis-main'
     metrics_path: /metrics
-    scrape_interval: 30s
+    scrape_interval: 15s
 
   - job_name: 'lunchchat-via-nginx'
     static_configs:
@@ -44,12 +47,14 @@ scrape_configs:
           service: 'lunchchat-backend'
           server_role: 'loadbalancer'
           server_name: 'nginx-loadbalancer'
+          instance: 'loadbalanced-app'
     metrics_path: /actuator/prometheus
     scheme: https
-    scrape_interval: 30s
+    scrape_interval: 15s
     scrape_timeout: 10s
 
 alerting:
   alertmanagers:
     - static_configs:
-        - targets: []
+        - targets:
+          - alertmanager:9093

--- a/monitoring/prometheus/rules/alerts.yml
+++ b/monitoring/prometheus/rules/alerts.yml
@@ -40,7 +40,7 @@ groups:
   - name: application
     rules:
       - alert: HighErrorRate
-        expr: rate(http_requests_total{status=~"5.."}[5m]) / rate(http_requests_total[5m]) * 100 > 5
+        expr: rate(http_server_requests_seconds_count{status=~"5.."}[5m]) / rate(http_server_requests_seconds_count[5m]) * 100 > 5
         for: 5m
         labels:
           severity: warning
@@ -49,7 +49,7 @@ groups:
           description: "Error rate is above 5% for more than 5 minutes on {{ $labels.instance }}"
 
       - alert: HighResponseTime
-        expr: histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m])) > 1
+        expr: histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket[5m])) by (le)) > 1
         for: 5m
         labels:
           severity: warning
@@ -78,7 +78,7 @@ groups:
           description: "Redis instance has been down for more than 2 minutes"
 
       - alert: RedisHighMemoryUsage
-        expr: redis_memory_used_bytes / redis_config_maxmemory * 100 > 90
+        expr: redis_memory_used_bytes / clamp_min(redis_config_maxmemory, 1) * 100 > 90
         for: 5m
         labels:
           severity: warning

--- a/monitoring/prometheus/rules/alerts.yml
+++ b/monitoring/prometheus/rules/alerts.yml
@@ -1,0 +1,87 @@
+groups:
+  - name: infrastructure
+    rules:
+      - alert: HighCPUUsage
+        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High CPU usage detected"
+          description: "CPU usage is above 80% for more than 5 minutes on {{ $labels.instance }}"
+
+      - alert: HighMemoryUsage
+        expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100 > 85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High memory usage detected"
+          description: "Memory usage is above 85% for more than 5 minutes on {{ $labels.instance }}"
+
+      - alert: DiskSpaceLow
+        expr: (node_filesystem_avail_bytes{fstype!="tmpfs"} / node_filesystem_size_bytes{fstype!="tmpfs"}) * 100 < 10
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Disk space low"
+          description: "Disk space is below 10% on {{ $labels.instance }}"
+
+      - alert: InstanceDown
+        expr: up == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Instance is down"
+          description: "{{ $labels.instance }} has been down for more than 5 minutes"
+
+  - name: application
+    rules:
+      - alert: HighErrorRate
+        expr: rate(http_requests_total{status=~"5.."}[5m]) / rate(http_requests_total[5m]) * 100 > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High error rate detected"
+          description: "Error rate is above 5% for more than 5 minutes on {{ $labels.instance }}"
+
+      - alert: HighResponseTime
+        expr: histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m])) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High response time detected"
+          description: "95th percentile response time is above 1s on {{ $labels.instance }}"
+
+      - alert: ApplicationDown
+        expr: up{job=~"lunchchat.*"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "LunchChat application is down"
+          description: "{{ $labels.job }} on {{ $labels.instance }} has been down for more than 2 minutes"
+
+  - name: database
+    rules:
+      - alert: RedisDown
+        expr: redis_up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Redis is down"
+          description: "Redis instance has been down for more than 2 minutes"
+
+      - alert: RedisHighMemoryUsage
+        expr: redis_memory_used_bytes / redis_config_maxmemory * 100 > 90
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Redis memory usage high"
+          description: "Redis memory usage is above 90%"


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #106 

## 🔑 주요 내용

- 무료 크레딧이 사용가능한 GCP 모니터링 서버를 추가로 띄워서 모니터링 서버를 분리했습니다.
- 기존 성능 최적화된 모니터링을 업그레이드하고, Discord 실시간 알림 시스템을 구축했습니다.
- 리소스를 6-10배 증가시켜 Prometheus(300MB→2GB), Grafana(150MB→512MB)로 확장하고 데이터 보관기간을 30일로 연장했습니다.
- Alertmanager + Discord Webhook을 통해 9개 알림 규칙(CPU/메모리/디스크/앱 다운 등)으로 실시간 장애 감지 및 크리티컬 알림을 구현했습니다.
- 보안을 고려해 GCP 모니터링 서버를 분리하고, 환경변수 기반 설정으로 민감정보를 보호하며 Grafana 대시보드를 개선했습니다.

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alertmanager 도입 및 Discord 웹훅 알림 템플릿 추가
  * Pushgateway/Alertmanager 서비스 추가로 모니터링 파이프라인 강화
  * Grafana 대시보드 개편: 요청률, 응답 지연(50/95 백분위), 오류율, Redis 및 서비스 상태 패널 추가
  * 신규 Prometheus 경고 규칙 세트(인프라/애플리케이션/데이터베이스) 추가

* **Chores**
  * 스크레이프/평가 주기 단축 및 Alertmanager 연동 설정
  * Prometheus/Grafana/Exporter 리소스·보존 기간·동시성 설정 개선
  * 배포 스크립트에 Alertmanager 구성 생성 단계 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->