### PR TITLE
[BUGFIX] 채팅방 조회 시 내 정보 반환 문제

### DIFF
--- a/src/main/java/com/lunchchat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/lunchchat/domain/chat/controller/ChatRoomController.java
@@ -39,9 +39,9 @@ public class ChatRoomController {
     @Operation(summary = "채팅방 생성")
     public ResponseEntity<ApiResponse<CreateChatRoomRes>> createChatRoom(@AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam Long friendId) {
-        Long starterId = userDetails.getMemberId();
+        Long userId = userDetails.getMemberId();
 
-        return ResponseEntity.ok(ApiResponse.onSuccess(chatRoomService.createRoom(starterId, friendId)));
+        return ResponseEntity.ok(ApiResponse.onSuccess(chatRoomService.createRoom(userId, friendId)));
     }
 
     //채팅방 리스트 조회


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- ex) feat/123-login-api

## 🔑 주요 내용

- 매칭 완료 탭에서 채팅방으로 들어갈 때 상대방 정보가 아닌 내 정보로 뜨는 문제 해결

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 채팅방 생성 시 현재 사용자 기준으로 상대방 정보(이름/부서)가 정확히 반환·표시되도록 수정했습니다.
  * 드물게 발생하던 잘못된 상대 매칭 표시 문제를 해소했습니다.
  * 채팅방 ID 반환은 기존과 동일하며, 사용성에 영향 없이 정보 정확도를 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->