### PR TITLE
[BUGFIX] 채팅방 조회시 lastMessageSendAt 갱신되는 문제 수정

### DIFF
--- a/src/main/java/com/lunchchat/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/lunchchat/domain/chat/entity/ChatRoom.java
@@ -32,14 +32,12 @@ public class ChatRoom extends BaseEntity {
         ChatRoom room = new ChatRoom();
         room.starter = starter;
         room.friend = friend;
-        room.lastMessageSendAt = LocalDateTime.now();
         return room;
     }
 
     public void activateRoom() {
         this.isExitedByStarter = false;
         this.isExitedByFriend = false;
-        this.lastMessageSendAt = LocalDateTime.now();
     }
 
     public void exit(Long userId) {


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- ex) feat/123-login-api

## 🔑 주요 내용

- 채팅 목록 조회시 메시지를 보내지 않더라도 lastMessageSendAt이 갱신돼버려 생기는 문제 수정

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 새로 생성되거나 활성화된 채팅방에서 실제 메시지가 없을 때 ‘마지막 메시지 시간’이 현재 시각으로 표시되던 현상을 수정했습니다. 이제 첫 메시지가 전송되기 전에는 해당 시간이 표시되지 않거나 비어 있을 수 있습니다. 채팅방 목록의 정렬과 표시가 실제 메시지 활동을 더 정확히 반영하며, 사용자는 처음 메시지를 보낼 때부터 시간 정보가 나타납니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->