### PR TITLE
[REFACTOR] pub/sub 롤백

### DIFF
--- a/src/main/java/com/lunchchat/domain/chat/dto/response/ChatMessageRes.java
+++ b/src/main/java/com/lunchchat/domain/chat/dto/response/ChatMessageRes.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import org.bson.types.ObjectId;
 
 public record ChatMessageRes(
-    String id,
+    ObjectId id,
     Long roomId,
     Long senderId,
     String content,
@@ -15,7 +15,7 @@ public record ChatMessageRes(
 ){
     public static ChatMessageRes from(ChatMessage chatMessage) {
         return new ChatMessageRes(
-            chatMessage.getId().toString(),
+            chatMessage.getId(),
             chatMessage.getChatRoomId(),
             chatMessage.getSenderId(),
             chatMessage.getContent(),
@@ -25,7 +25,7 @@ public record ChatMessageRes(
 
     public static ChatMessageRes of(Long roomId, ChatMessage message) {
         return new ChatMessageRes(
-            message.getId().toString(),
+            message.getId(),
             roomId,
             message.getSenderId(),
             message.getContent(),

--- a/src/main/java/com/lunchchat/domain/chat/redis/RedisPublisher.java
+++ b/src/main/java/com/lunchchat/domain/chat/redis/RedisPublisher.java
@@ -1,18 +1,18 @@
-//package com.lunchchat.domain.chat.redis;
-//
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.data.redis.core.RedisTemplate;
-//import org.springframework.stereotype.Component;
-//
-//@Component
-//@RequiredArgsConstructor
-//public class RedisPublisher {
-//
-//    private final RedisTemplate<String, Object> redisTemplate;
-//
-//    // 메시지를 발행
-//    public void publish(String channel, Object message) {
-//        redisTemplate.convertAndSend(channel, message);
-//    }
-//
-//}
+package com.lunchchat.domain.chat.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisPublisher {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // 메시지를 발행
+    public void publish(String channel, Object message) {
+        redisTemplate.convertAndSend(channel, message);
+    }
+
+}

--- a/src/main/java/com/lunchchat/domain/chat/redis/RedisStreamConsumer.java
+++ b/src/main/java/com/lunchchat/domain/chat/redis/RedisStreamConsumer.java
@@ -1,90 +1,90 @@
-package com.lunchchat.domain.chat.redis;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.lunchchat.domain.chat.dto.response.ChatMessageRes;
-import jakarta.annotation.PostConstruct;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.Map;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.stream.Consumer;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ReadOffset;
-import org.springframework.data.redis.connection.stream.StreamOffset;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.stream.StreamListener;
-import org.springframework.data.redis.stream.StreamMessageListenerContainer;
-import org.springframework.data.redis.stream.Subscription;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
-import org.springframework.stereotype.Component;
-
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class RedisStreamConsumer implements StreamListener<String, MapRecord<String, String, String>> {
-
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final SimpMessageSendingOperations messagingTemplate;
-    private final ObjectMapper objectMapper;
-
-    private static final String STREAM_KEY = "chat-stream";
-    private static final String GROUP = "chat-group";   // 모든 서버가 같은 그룹
-    private static final String CONSUMER = "chat-consumer-" + System.currentTimeMillis();
-
-    @PostConstruct
-    public void init() {
-        try {
-            // 처음 실행 시 Stream에 Consumer Group 생성
-            redisTemplate.opsForStream().createGroup(STREAM_KEY, GROUP);
-        } catch (Exception e) {
-            log.info("Consumer group already exists: {}", GROUP);
-        }
-
-        // ListenerContainer 설정
-        StreamMessageListenerContainer.StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
-                StreamMessageListenerContainer.StreamMessageListenerContainerOptions
-                        .builder()
-                        .pollTimeout(Duration.ofSeconds(2))
-                        .build();
-
-        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container =
-                StreamMessageListenerContainer.create(redisTemplate.getConnectionFactory(), options); //ListenerContainer 시작
-        //내부적으로 group에 속한 consumer는 XREADGROUP 명령을 실행해 메시지를 Polling
-
-
-        Subscription subscription = container.receive(
-                Consumer.from(GROUP, CONSUMER),
-                StreamOffset.create(STREAM_KEY, ReadOffset.lastConsumed()),
-                this
-        );
-
-        container.start();
-        log.info("Redis Stream Consumer started with consumer: {}", CONSUMER);
-    }
-
-    // producer가 발행한 메시지를 chat-group 내 한 Consumer에게 전송
-    @Override
-    public void onMessage(MapRecord<String, String, String> message) {
-        try {
-            Map<String, String> map = message.getValue();
-
-            ChatMessageRes chatMessage = new ChatMessageRes(
-                    map.get("id"),
-                    Long.parseLong(map.get("roomId").replace("\"", "")),
-                    Long.parseLong(map.get("senderId").replace("\"", "")),
-                    map.get("content"),
-                    LocalDateTime.parse(map.get("createdAt").replace("\"", "")) // ISO-8601 문자열로 변환
-            );
-
-            messagingTemplate.convertAndSend("/sub/rooms/" + chatMessage.roomId(), chatMessage);
-            log.info("Consumed message: {}", chatMessage);
-
-            // ack 처리 (동일 메시지를 여러 consumer가 처리하지 않도록)
-            redisTemplate.opsForStream().acknowledge(STREAM_KEY, GROUP, message.getId());
-
-        } catch (Exception e) {
-            log.error("Redis Stream 메시지 처리 실패", e);
-        }
-    }
-}
+//package com.lunchchat.domain.chat.redis;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.lunchchat.domain.chat.dto.response.ChatMessageRes;
+//import jakarta.annotation.PostConstruct;
+//import java.time.Duration;
+//import java.time.LocalDateTime;
+//import java.util.Map;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.data.redis.connection.stream.Consumer;
+//import org.springframework.data.redis.connection.stream.MapRecord;
+//import org.springframework.data.redis.connection.stream.ReadOffset;
+//import org.springframework.data.redis.connection.stream.StreamOffset;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.data.redis.stream.StreamListener;
+//import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+//import org.springframework.data.redis.stream.Subscription;
+//import org.springframework.messaging.simp.SimpMessageSendingOperations;
+//import org.springframework.stereotype.Component;
+//
+//@Slf4j
+//@Component
+//@RequiredArgsConstructor
+//public class RedisStreamConsumer implements StreamListener<String, MapRecord<String, String, String>> {
+//
+//    private final RedisTemplate<String, Object> redisTemplate;
+//    private final SimpMessageSendingOperations messagingTemplate;
+//    private final ObjectMapper objectMapper;
+//
+//    private static final String STREAM_KEY = "chat-stream";
+//    private static final String GROUP = "chat-group";   // 모든 서버가 같은 그룹
+//    private static final String CONSUMER = "chat-consumer-" + System.currentTimeMillis();
+//
+//    @PostConstruct
+//    public void init() {
+//        try {
+//            // 처음 실행 시 Stream에 Consumer Group 생성
+//            redisTemplate.opsForStream().createGroup(STREAM_KEY, GROUP);
+//        } catch (Exception e) {
+//            log.info("Consumer group already exists: {}", GROUP);
+//        }
+//
+//        // ListenerContainer 설정
+//        StreamMessageListenerContainer.StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
+//                StreamMessageListenerContainer.StreamMessageListenerContainerOptions
+//                        .builder()
+//                        .pollTimeout(Duration.ofSeconds(2))
+//                        .build();
+//
+//        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container =
+//                StreamMessageListenerContainer.create(redisTemplate.getConnectionFactory(), options); //ListenerContainer 시작
+//        //내부적으로 group에 속한 consumer는 XREADGROUP 명령을 실행해 메시지를 Polling
+//
+//
+//        Subscription subscription = container.receive(
+//                Consumer.from(GROUP, CONSUMER),
+//                StreamOffset.create(STREAM_KEY, ReadOffset.lastConsumed()),
+//                this
+//        );
+//
+//        container.start();
+//        log.info("Redis Stream Consumer started with consumer: {}", CONSUMER);
+//    }
+//
+//    // producer가 발행한 메시지를 chat-group 내 한 Consumer에게 전송
+//    @Override
+//    public void onMessage(MapRecord<String, String, String> message) {
+//        try {
+//            Map<String, String> map = message.getValue();
+//
+//            ChatMessageRes chatMessage = new ChatMessageRes(
+//                    map.get("id"),
+//                    Long.parseLong(map.get("roomId").replace("\"", "")),
+//                    Long.parseLong(map.get("senderId").replace("\"", "")),
+//                    map.get("content"),
+//                    LocalDateTime.parse(map.get("createdAt").replace("\"", "")) // ISO-8601 문자열로 변환
+//            );
+//
+//            messagingTemplate.convertAndSend("/sub/rooms/" + chatMessage.roomId(), chatMessage);
+//            log.info("Consumed message: {}", chatMessage);
+//
+//            // ack 처리 (동일 메시지를 여러 consumer가 처리하지 않도록)
+//            redisTemplate.opsForStream().acknowledge(STREAM_KEY, GROUP, message.getId());
+//
+//        } catch (Exception e) {
+//            log.error("Redis Stream 메시지 처리 실패", e);
+//        }
+//    }
+//}

--- a/src/main/java/com/lunchchat/domain/chat/redis/RedisStreamProducer.java
+++ b/src/main/java/com/lunchchat/domain/chat/redis/RedisStreamProducer.java
@@ -1,55 +1,55 @@
-package com.lunchchat.domain.chat.redis;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.lunchchat.domain.chat.dto.response.ChatMessageRes;
-import java.util.Map;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ObjectRecord;
-import org.springframework.data.redis.connection.stream.RecordId;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Component;
-
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class RedisStreamProducer {
-
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final ObjectMapper objectMapper;
-
-    private static final String STREAM_KEY = "chat-stream"; // stream 이름
-
-    public void produce(ChatMessageRes message) {
-        try {
-            // 모든 값을 문자열로 변환하여 Map에 저장
-            Map<String, String> map = Map.of(
-                    "id", message.id(),
-                    "roomId", String.valueOf(message.roomId()),
-                    "senderId", String.valueOf(message.senderId()),
-                    "content", message.content(),
-                    "createdAt", message.createdAt().toString() // ISO-8601 문자열
-            );
-
-            // MapRecord로 Stream에 추가
-            redisTemplate.opsForStream().add(MapRecord.create(STREAM_KEY, map));
-
-            log.info("Produced to stream {}: {}", STREAM_KEY, map);
-        } catch (Exception e) {
-            log.error("Redis Stream produce 실패", e);
-        }
-    }
-
-//    public void produce(Object message) {
+//package com.lunchchat.domain.chat.redis;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.lunchchat.domain.chat.dto.response.ChatMessageRes;
+//import java.util.Map;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.data.redis.connection.stream.MapRecord;
+//import org.springframework.data.redis.connection.stream.ObjectRecord;
+//import org.springframework.data.redis.connection.stream.RecordId;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.stereotype.Component;
+//
+//@Slf4j
+//@Component
+//@RequiredArgsConstructor
+//public class RedisStreamProducer {
+//
+//    private final RedisTemplate<String, Object> redisTemplate;
+//    private final ObjectMapper objectMapper;
+//
+//    private static final String STREAM_KEY = "chat-stream"; // stream 이름
+//
+//    public void produce(ChatMessageRes message) {
 //        try {
-//            //Redis는 chat-stream이라는 Stream에 새로운 메시지를 기록
-//            ObjectRecord<String, Object> record = ObjectRecord.create(STREAM_KEY, message);
-//            // 메시지마다 고유 RecordId가 부여
-//            RecordId recordId = redisTemplate.opsForStream().add(record);
-//            log.info("Produced to stream {} with id {}", STREAM_KEY, recordId);
+//            // 모든 값을 문자열로 변환하여 Map에 저장
+//            Map<String, String> map = Map.of(
+//                    "id", message.id(),
+//                    "roomId", String.valueOf(message.roomId()),
+//                    "senderId", String.valueOf(message.senderId()),
+//                    "content", message.content(),
+//                    "createdAt", message.createdAt().toString() // ISO-8601 문자열
+//            );
+//
+//            // MapRecord로 Stream에 추가
+//            redisTemplate.opsForStream().add(MapRecord.create(STREAM_KEY, map));
+//
+//            log.info("Produced to stream {}: {}", STREAM_KEY, map);
 //        } catch (Exception e) {
 //            log.error("Redis Stream produce 실패", e);
 //        }
 //    }
-}
+//
+////    public void produce(Object message) {
+////        try {
+////            //Redis는 chat-stream이라는 Stream에 새로운 메시지를 기록
+////            ObjectRecord<String, Object> record = ObjectRecord.create(STREAM_KEY, message);
+////            // 메시지마다 고유 RecordId가 부여
+////            RecordId recordId = redisTemplate.opsForStream().add(record);
+////            log.info("Produced to stream {} with id {}", STREAM_KEY, recordId);
+////        } catch (Exception e) {
+////            log.error("Redis Stream produce 실패", e);
+////        }
+////    }
+//}

--- a/src/main/java/com/lunchchat/domain/chat/redis/RedisSubscriber.java
+++ b/src/main/java/com/lunchchat/domain/chat/redis/RedisSubscriber.java
@@ -1,35 +1,35 @@
-//package com.lunchchat.domain.chat.redis;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.lunchchat.domain.chat.dto.response.ChatMessageRes;
-//import java.nio.charset.StandardCharsets;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.data.redis.connection.Message;
-//import org.springframework.data.redis.connection.MessageListener;
-//import org.springframework.messaging.simp.SimpMessageSendingOperations;
-//import org.springframework.stereotype.Component;
-//
-//@Slf4j
-//@Component
-//@RequiredArgsConstructor
-//public class RedisSubscriber implements MessageListener {
-//
-//    private final ObjectMapper objectMapper;
-//    private final SimpMessageSendingOperations messagingTemplate;
-//
-//    // Redis에서 메시지를 수신 시 호출되는 메서드
-//    @Override
-//    public void onMessage(Message message, byte[] pattern) {
-//        try {
-//            String msgBody = new String(message.getBody(), StandardCharsets.UTF_8);
-//            ChatMessageRes chatMessage = objectMapper.readValue(msgBody, ChatMessageRes.class);
-//
-//            messagingTemplate.convertAndSend("/sub/rooms/" + chatMessage.roomId(), chatMessage);
-//
-//        } catch (Exception e) {
-//            log.error("Redis 구독 메시지 처리 실패", e);
-//        }
-//    }
-//
-//}
+package com.lunchchat.domain.chat.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lunchchat.domain.chat.dto.response.ChatMessageRes;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    // Redis에서 메시지를 수신 시 호출되는 메서드
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String msgBody = new String(message.getBody(), StandardCharsets.UTF_8);
+            ChatMessageRes chatMessage = objectMapper.readValue(msgBody, ChatMessageRes.class);
+
+            messagingTemplate.convertAndSend("/sub/rooms/" + chatMessage.roomId(), chatMessage);
+
+        } catch (Exception e) {
+            log.error("Redis 구독 메시지 처리 실패", e);
+        }
+    }
+
+}

--- a/src/main/java/com/lunchchat/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/lunchchat/domain/chat/service/ChatMessageService.java
@@ -4,8 +4,7 @@ import com.lunchchat.domain.chat.entity.ChatMessage;
 import com.lunchchat.domain.chat.entity.ChatRoom;
 import com.lunchchat.domain.chat.dto.request.ChatMessageReq;
 import com.lunchchat.domain.chat.dto.response.ChatMessageRes;
-//import com.lunchchat.domain.chat.redis.RedisPublisher;
-import com.lunchchat.domain.chat.redis.RedisStreamProducer;
+import com.lunchchat.domain.chat.redis.RedisPublisher;
 import com.lunchchat.domain.chat.repository.ChatRoomRepository;
 import com.lunchchat.domain.chat.repository.ChatMessageRepository;
 import com.lunchchat.domain.member.entity.Member;
@@ -24,8 +23,7 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final MemberRepository memberRepository;
 //    private final SimpMessageSendingOperations messagingTemplate;
-//    private final RedisPublisher redisPublisher;
-    private final RedisStreamProducer redisStreamProducer;
+    private final RedisPublisher redisPublisher;
 
     // 메시지 전송 로직 구현
     @Transactional
@@ -53,8 +51,7 @@ public class ChatMessageService {
         ChatMessageRes chatMessageRes = ChatMessageRes.of(roomId, message);
 
 //        messagingTemplate.convertAndSend("/sub/rooms/" + roomId, chatMessageRes);
-//        redisPublisher.publish("chat", chatMessageRes);
-        redisStreamProducer.produce(chatMessageRes);
+        redisPublisher.publish("chat", chatMessageRes);
 
         //알림 로직 구현시 추가
     }

--- a/src/main/java/com/lunchchat/global/config/RedisConfig.java
+++ b/src/main/java/com/lunchchat/global/config/RedisConfig.java
@@ -3,6 +3,7 @@ package com.lunchchat.global.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.lunchchat.domain.chat.redis.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -55,21 +56,21 @@ public class RedisConfig {
         return template;
     }
 
-//    // 3. Redis 메시지 구독 처리 (Pub/Sub)
-//    @Bean
-//    public MessageListenerAdapter listenerAdapter(RedisSubscriber subscriber) {
-//        return new MessageListenerAdapter(subscriber, "onMessage");
-//    }
-//
-//    @Bean
-//    public RedisMessageListenerContainer redisMessageListenerContainer(
-//            RedisConnectionFactory connectionFactory,
-//            MessageListenerAdapter listenerAdapter) {
-//
-//        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-//        container.setConnectionFactory(connectionFactory);
-//        container.addMessageListener(listenerAdapter, new PatternTopic("chat"));
-//        return container;
-//    }
+    // 3. Redis 메시지 구독 처리 (Pub/Sub)
+    @Bean
+    public MessageListenerAdapter listenerAdapter(RedisSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, "onMessage");
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter listenerAdapter) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(listenerAdapter, new PatternTopic("chat"));
+        return container;
+    }
 
 }


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- ex) feat/123-login-api

## 🔑 주요 내용

- 채팅 전송 속도 지연으로 일단 기존 로직대로 롤백

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Redis Pub/Sub 기반 실시간 채팅 전달 활성화로 메시지가 WebSocket 구독 경로로 즉시 전송됩니다.
- Refactor
  - 메시징 인프라를 Redis Streams에서 Pub/Sub로 전환하여 전달 경로를 단순화했습니다.
  - API 변경: 응답 메시지의 ID 형식이 문자열에서 ObjectId 기반으로 변경되었습니다.
- Chores
  - Redis 메시지 리스너 및 구독 토픽(chat) 설정을 추가하여 운영 구독을 활성화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->