### PR TITLE
[DEPLOY] JVM 최적화

### DIFF
--- a/ansible/templates/docker-compose.app.yml.j2
+++ b/ansible/templates/docker-compose.app.yml.j2
@@ -8,7 +8,7 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
       - SERVER_PORT=8080
       - TZ=Asia/Seoul
-      - JAVA_OPTS=-Xms512m -Xmx1g -XX:+UseG1GC -XX:+UseStringDeduplication
+      - JAVA_OPTS=-Xms256m -Xmx700m -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:+UseStringDeduplication -XX:G1HeapRegionSize=8m -XX:MaxMetaspaceSize=120m -XX:+DisableExplicitGC -XX:+UseCompressedOops -XX:G1NewSizePercent=25 -XX:G1MaxNewSizePercent=35
       - DB_URL={{ db_url }}
       - DB_USER={{ db_user }}
       - DB_PW={{ db_pw }}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #124 

## 🔑 주요 내용

 - t2.micro EC2(1GB RAM) 환경에 맞는 JVM 메모리 최적화
  - 기존 과도한 힙 메모리 할당 조정 (Xms: 512m→256m, Xmx: 1g→700m)
  - 메타스페이스 크기 제한으로 메모리 사용량 추가 절약 (MaxMetaspaceSize: 120m)
  - G1GC 성능 튜닝으로 동시 접속자 처리 능력 향상
  - 예상 효과: 메모리 사용률 80% → 50-60%로 감소
## 실제 결과
### 기존 서버 상태
<img width="251" height="82" alt="image" src="https://github.com/user-attachments/assets/80d66791-5a83-4e99-b475-bc2450ee42ad" />

# ↓
### 바뀐 서버 상태
<img width="257" height="94" alt="image" src="https://github.com/user-attachments/assets/1e185279-b694-4396-8218-0608b4856bfe" />


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
